### PR TITLE
Added CLI cmd to destroy demo traffic stacks

### DIFF
--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -4,6 +4,7 @@ import logging
 import click
 
 from manage_arkime.commands.deploy_demo_traffic import cmd_deploy_demo_traffic
+from manage_arkime.commands.destroy_demo_traffic import cmd_destroy_demo_traffic
 from manage_arkime.logging_wrangler import LoggingWrangler
 
 logger = logging.getLogger(__name__)
@@ -35,6 +36,14 @@ def deploy_demo_traffic(ctx):
     region = ctx.obj.get("region")
     cmd_deploy_demo_traffic(profile, region)
 cli.add_command(deploy_demo_traffic)
+
+@click.command(help="Uses CDK to destroy previously-deployed sample traffic sources in your account")
+@click.pass_context
+def destroy_demo_traffic(ctx):
+    profile = ctx.obj.get("profile")
+    region = ctx.obj.get("region")
+    cmd_destroy_demo_traffic(profile, region)
+cli.add_command(destroy_demo_traffic)
 
 
 def main():

--- a/manage_arkime/cdk_exceptions.py
+++ b/manage_arkime/cdk_exceptions.py
@@ -66,3 +66,7 @@ class CdkBootstrapFailedUnknown(Exception):
 class CdkDeployFailedUnknown(Exception):
     def __init__(self):
         super().__init__("The CDK Deploy operation failed for unknown reasons, please check the logs and stdout.")
+
+class CdkDestroyFailedUnknown(Exception):
+    def __init__(self):
+        super().__init__("The CDK Destroy operation failed for unknown reasons, please check the logs and stdout.")

--- a/manage_arkime/commands/destroy_demo_traffic.py
+++ b/manage_arkime/commands/destroy_demo_traffic.py
@@ -1,0 +1,13 @@
+import logging
+
+import manage_arkime.cdk_client as cdk
+import manage_arkime.constants as constants
+
+logger = logging.getLogger(__name__)
+
+def cmd_destroy_demo_traffic(profile: str, region: str):
+    logger.debug(f"Invoking destroy-demo-traffic with profile '{profile}' and region '{region}'")
+
+    cdk_client = cdk.CdkClient()
+    stacks_to_destroy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
+    cdk_client.destroy(stacks_to_destroy, aws_profile=profile, aws_region=region)


### PR DESCRIPTION
## Description
Added a CLI command to tear down the demo traffic stacks created by `deploy-demo-traffic`.  This makes testing easier and paves the way for being able to deploy/destroy our Arkime cluster stacks.

See:
* https://github.com/arkime/cloud-demo/issues/4
* https://github.com/arkime/cloud-demo/issues/12

Testing:
* Added unit tests
* Ran the command manually against my account:
```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py destroy-demo-traffic
2023-03-27 12:41:24 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-03-27 12:41:24 - Using AWS Credential Profile: default
2023-03-27 12:41:24 - Using AWS Region: default from AWS Config settings
2023-03-27 12:41:24 - Found credentials in shared credentials file: ~/.aws/credentials
2023-03-27 12:41:25 - ================================================================================
2023-03-27 12:41:25 - USER ACTION REQUIRED:
2023-03-27 12:41:25 - --------------------------------------------------------------------------------
Your command will result in the the following CloudFormation stacks being destroyed in AWS Account XXXXXXXXXXXX and Region us-east-2: ['DemoTrafficGen01', 'DemoTrafficGen02']

Do you wish to proceed (y/yes or n/no)? yes
2023-03-27 12:41:30 - Executing command: destroy --force DemoTrafficGen01 DemoTrafficGen02
2023-03-27 12:41:30 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-03-27 12:45:19 - Destruction succeeded
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py destroy-demo-traffic
2023-03-27 12:48:30 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-03-27 12:48:30 - Using AWS Credential Profile: default
2023-03-27 12:48:30 - Using AWS Region: default from AWS Config settings
2023-03-27 12:48:30 - Found credentials in shared credentials file: ~/.aws/credentials
2023-03-27 12:48:31 - ================================================================================
2023-03-27 12:48:31 - USER ACTION REQUIRED:
2023-03-27 12:48:31 - --------------------------------------------------------------------------------
Your command will result in the the following CloudFormation stacks being destroyed in AWS Account XXXXXXXXXXXX and Region us-east-2: ['DemoTrafficGen01', 'DemoTrafficGen02']

Do you wish to proceed (y/yes or n/no)? n
2023-03-27 12:48:36 - Aborting per user response
```