### PR TITLE
Set up context passing from Python to CDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,36 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Next, invoke the management CLI.  It will use your default AWS Credentials and Region unless you specify otherwise (see `./manage_arkime.py --help`).
+Next, pull in the Node dependencies required for the CDK:
+
+```
+npm ci
+```
+
+Finally, invoke the management CLI.  It will use your default AWS Credentials and Region unless you specify otherwise (see `./manage_arkime.py --help`).
 
 ```
 ./manage_arkime.py deploy-demo-traffic
+```
+
+You can tear down the demo Fargate stacks using an additional command:
+
+```
+./manage_arkime.py deploy-demo-traffic
+```
+
+## How to shell into the Fargate containers
+
+It's possible to create interactive terminal sessions inside the Fargate Docker containers deployed into your account.  The official documentation/blog posts are a bit confusing, so we explain the process here.  The Fargate tasks we spin up have all been pre-configured on the server-side to enable this, so what you need to do is the stuff on the client-side (e.g. your laptop).  This process involves using the ECS Exec capability to perform a remote Docker Exec, and works even if your Tasks are running in private subnets.  You can learn way more in [this (verbose/confusing) blog post](https://aws.amazon.com/blogs/containers/new-using-amazon-ecs-exec-access-your-containers-fargate-ec2/).
+
+First, you need a recent version of the AWS CLI that has the required commands.  You can install/update your installation with [the instructions here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+
+Second, you need to install the Session Manager Plugin for the AWS CLI using [the instructions here](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html).
+
+Finally, you can create an interactive session using the AWS CLI.  You'll need to know the Cluster ID and the Task ID, which you can find either using the AWS CLI or the AWS Console.
+
+```
+aws ecs execute-command --cluster <your cluster ID> --container FargateContainer --task <your task id> --interactive --command "/bin/sh"
 ```
 
 ## How to run the unit tests

--- a/cdk-lib/capture-stacks/capture-vpc-stack.ts
+++ b/cdk-lib/capture-stacks/capture-vpc-stack.ts
@@ -1,0 +1,41 @@
+import { Construct } from 'constructs';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import { Stack, StackProps } from 'aws-cdk-lib';
+
+export class CaptureVpcStack extends Stack {
+  public readonly vpc: ec2.Vpc;
+  public readonly flowLog: ec2.FlowLog;
+
+  constructor(scope: Construct, id: string, props: StackProps) {
+    super(scope, id, props);
+
+    this.vpc = new ec2.Vpc(this, 'VPC', {
+        maxAzs: 3,
+        subnetConfiguration: [
+            {
+                subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+                name: 'CaptureNodes',
+                cidrMask: 24
+            },
+            {
+                subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+                name: 'Database',
+                cidrMask: 24
+            }
+            ]
+        });
+    
+        const flowLogsGroup = new logs.LogGroup(this, 'FlowLogsLogGroup', {
+            logGroupName: `FlowLogs-${id}`,
+            removalPolicy: RemovalPolicy.RETAIN,
+            retention: logs.RetentionDays.TEN_YEARS,
+        });
+    
+        this.flowLog = new ec2.FlowLog(this, 'FlowLogs', {
+            resourceType: ec2.FlowLogResourceType.fromVpc(this.vpc),
+            destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogsGroup),
+        });
+  }
+}

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -1,29 +1,44 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
+import * as context from './core/context-wrangling';
+import * as prms from './core/command-params';
 import { TrafficGenStack } from './traffic-gen-sample/traffic-gen-stack';
+import { CaptureVpcStack } from './capture-stacks/capture-vpc-stack';
 import { Environment } from 'aws-cdk-lib';
 
 const app = new cdk.App();
 
-// This ENV variable is set by the CDK CLI.  It reads it from your AWS Credential profile, and configures the var
-// before invoking CDK actions.
-const aws_account: string | undefined = process.env.CDK_DEFAULT_ACCOUNT
+const params: (prms.CreateClusterParams | prms.DeployDemoTrafficParams | prms.DestroyDemoTrafficParams) = context.getCommandParams(app);
 
-// Like the CDK_DEFAULT_ACCOUNT, the CDK CLI sets the CDK_DEFAULT_REGION by reading the AWS Credential profile.
-// However, we want the user to to able to specify a different region than the default so we optionaly pass in one
-// via CDK Context ourselves.
-const region_context = app.node.tryGetContext("ARKIME_REGION")
-const aws_region: string | undefined = region_context ?? process.env.CDK_DEFAULT_REGION
-
-const demo_env: Environment = { 
-    account: aws_account, 
-    region: aws_region
+const env: Environment = { 
+    account: params.awsAccount, 
+    region: params.awsRegion
 }
 
-new TrafficGenStack(app, 'DemoTrafficGen01', {
-    env: demo_env
-});
-new TrafficGenStack(app, 'DemoTrafficGen02', {
-    env: demo_env
-});
+switch(params.type) {
+    case "CreateClusterParams":
+        new CaptureVpcStack(app, params.nameCaptureVpc, {
+            env: env
+        });
+        break;
+    case "DeployDemoTrafficParams":
+        new TrafficGenStack(app, 'DemoTrafficGen01', {
+            env: env
+        });
+        new TrafficGenStack(app, 'DemoTrafficGen02', {
+            env: env
+        });
+        break;
+    case "DestroyDemoTrafficParams":
+        new TrafficGenStack(app, 'DemoTrafficGen01', {
+            env: env
+        });
+        new TrafficGenStack(app, 'DemoTrafficGen02', {
+            env: env
+        });
+        break;
+}
+
+
+

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -1,0 +1,49 @@
+/**
+ * Base type for receiving arguments from the Python side of the app.  These directly match the interface on the Python
+ * side for a given command and can be type-cast into using JSON.  It's expected these will only be used during the
+ * creation of CommandParams objects and discarded once one of those is created.
+ */
+export interface CommandParamsRaw { }
+
+/**
+ * Type to receive the raw Create Cluster arguments from Python
+ */
+export interface CreateClusterParamsRaw extends CommandParamsRaw {
+    type: "CreateClusterParamsRaw";
+    nameCaptureVpc: string;
+}
+
+/**
+ * Base type for storing arguments received from the Python side of the app.  These may be embellished with additional
+ * details not present in the raw arguments from Python.  The rest of the CDK App will use these types to seed stack
+ * generation configuration based.
+ */
+export interface CommandParams {
+    awsAccount: string;
+    awsRegion: string;
+}
+
+/**
+ * Receptacle type to store arguments for Deploy Demo Traffic calls
+ */
+export interface DeployDemoTrafficParams extends CommandParams {
+    type: "DeployDemoTrafficParams";
+    // same as base for now
+}
+
+/**
+ * Receptacle type to store arguments for Destroy Demo Traffic calls
+ */
+export interface DestroyDemoTrafficParams extends CommandParams {
+    type: "DestroyDemoTrafficParams";
+    // same as base for now
+}
+
+/**
+ * Receptacle type to store arguments for Create Cluster calls
+ */
+export interface CreateClusterParams extends CommandParams {
+    type: "CreateClusterParams"
+    nameCaptureVpc: string;
+}
+

--- a/cdk-lib/core/constants.ts
+++ b/cdk-lib/core/constants.ts
@@ -1,0 +1,18 @@
+/**
+ * CDK Context variables the Python side will pass information through.  Currently hardcoded over there as well.
+ */
+export const CDK_CONTEXT_CMD_VAR: string = "ARKIME_CMD"
+export const CDK_CONTEXT_REGION_VAR: string = "ARKIME_REGION"
+export const CDK_CONTEXT_PARAMS_VAR: string = "ARKIME_PARAMS"
+
+/**
+ * These map directly to the specific commands executed by the user via the management CLI.  Since the strings are
+ * shared between the TypeScript and Python sides of the application, they should ideally be in a shared config file
+ * rather than hardcoded in both locations.
+ */
+export enum ManagementCmd {
+    DeployDemoTraffic = "DeployDemoTraffic",
+    DestroyDemoTraffic = "DestroyDemoTraffic",
+    CreateCluster = "CreateCluster",
+}
+

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -3,6 +3,7 @@ import logging
 
 import click
 
+from manage_arkime.commands.create_cluster import cmd_create_cluster
 from manage_arkime.commands.deploy_demo_traffic import cmd_deploy_demo_traffic
 from manage_arkime.commands.destroy_demo_traffic import cmd_destroy_demo_traffic
 from manage_arkime.logging_wrangler import LoggingWrangler
@@ -44,6 +45,15 @@ def destroy_demo_traffic(ctx):
     region = ctx.obj.get("region")
     cmd_destroy_demo_traffic(profile, region)
 cli.add_command(destroy_demo_traffic)
+
+@click.command(help="Creates an Arkime Cluster in your account")
+@click.option("--name", help="The name you want your Arkime Cluster and its associated resources to have")
+@click.pass_context
+def create_cluster(ctx, name):
+    profile = ctx.obj.get("profile")
+    region = ctx.obj.get("region")
+    cmd_create_cluster(profile, region, name)
+cli.add_command(create_cluster)
 
 
 def main():

--- a/manage_arkime/cdk_exceptions.py
+++ b/manage_arkime/cdk_exceptions.py
@@ -30,7 +30,8 @@ EXPIRED_CREDS_1: str = "There are expired AWS credentials in your environment"
 EXPIRED_CREDS_2: str = "ExpiredToken: The security token included in the request is expired"
 INVALID_TOKEN: str = "The security token included in the request is invalid"
 SIG_MISMATCH: str = "The request signature we calculated does not match the signature you provided"
-NOT_BOOTSTRAPPED: str = "Please run 'cdk bootstrap'"
+NOT_BOOTSTRAPPED_1: str = "Please run 'cdk bootstrap'"
+NOT_BOOTSTRAPPED_2: str = "Is this account bootstrapped?"
 
 def raise_common_exceptions(exit_code: int, stdout: List[str]) -> None:
     """
@@ -52,7 +53,9 @@ def raise_common_exceptions(exit_code: int, stdout: List[str]) -> None:
             raise CommonInvalidAWSToken()
         if re.search(SIG_MISMATCH, line):
             raise CommonAWSCredentialsSigMismatch()
-        if re.search(NOT_BOOTSTRAPPED, line):
+        if re.search(NOT_BOOTSTRAPPED_1, line):
+            raise CommonCdkNotBootstrapped()
+        if re.search(NOT_BOOTSTRAPPED_2, line):
             raise CommonCdkNotBootstrapped()
 
 # =============================================================================

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -1,0 +1,29 @@
+import json
+import logging
+import shlex
+from typing import Dict
+
+from manage_arkime.cdk_client import CdkClient
+import manage_arkime.constants as constants
+
+logger = logging.getLogger(__name__)
+
+def cmd_create_cluster(profile: str, region: str, name: str):
+    logger.debug(f"Invoking create-cluster with profile '{profile}' and region '{region}'")
+
+    cdk_client = CdkClient()
+    stacks_to_deploy = [
+        constants.get_capture_vpc_stack_name(name)
+    ]
+    context = _generate_cdk_context(name)
+    cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=context)
+
+def _generate_cdk_context(name: str) -> Dict[str, str]:
+    cmd_params = {
+        "nameCaptureVpc": constants.get_capture_vpc_stack_name(name)
+    }
+
+    return {
+        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_CREATE_CLUSTER,
+        constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps(cmd_params))
+    }

--- a/manage_arkime/commands/deploy_demo_traffic.py
+++ b/manage_arkime/commands/deploy_demo_traffic.py
@@ -1,6 +1,6 @@
 import logging
 
-import manage_arkime.cdk_client as cdk
+from manage_arkime.cdk_client import CdkClient
 import manage_arkime.constants as constants
 
 logger = logging.getLogger(__name__)
@@ -8,6 +8,9 @@ logger = logging.getLogger(__name__)
 def cmd_deploy_demo_traffic(profile: str, region: str):
     logger.debug(f"Invoking deploy-demo-traffic with profile '{profile}' and region '{region}'")
 
-    cdk_client = cdk.CdkClient()
+    cdk_client = CdkClient()
     stacks_to_deploy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
-    cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region)
+    context = {
+        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DEPLOY_DEMO
+    }
+    cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=context)

--- a/manage_arkime/commands/destroy_demo_traffic.py
+++ b/manage_arkime/commands/destroy_demo_traffic.py
@@ -1,6 +1,6 @@
 import logging
 
-import manage_arkime.cdk_client as cdk
+from manage_arkime.cdk_client import CdkClient
 import manage_arkime.constants as constants
 
 logger = logging.getLogger(__name__)
@@ -8,6 +8,9 @@ logger = logging.getLogger(__name__)
 def cmd_destroy_demo_traffic(profile: str, region: str):
     logger.debug(f"Invoking destroy-demo-traffic with profile '{profile}' and region '{region}'")
 
-    cdk_client = cdk.CdkClient()
+    cdk_client = CdkClient()
     stacks_to_destroy = [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2]
-    cdk_client.destroy(stacks_to_destroy, aws_profile=profile, aws_region=region)
+    context = {
+        constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DESTROY_DEMO
+    }
+    cdk_client.destroy(stacks_to_destroy, aws_profile=profile, aws_region=region, context=context)

--- a/manage_arkime/constants.py
+++ b/manage_arkime/constants.py
@@ -4,10 +4,54 @@
 # They should probably live in a shared config file or something.
 # =================================================================================================
 
+# The context key that the CDK App is looking for to know what command the user ran.  This is relevant as it helps the
+# CDK know which CloudFormation templates to generate.
+CDK_CONTEXT_CMD_VAR: str = "ARKIME_CMD"
+
+# The context key that the CDK App is looking for to receive stack configuration details through.  This configuration
+# must flow from the Python side to the CDK side because the management CLI is tracking the application "state", not
+# the CDK App.  It's unclear how sustainable this approach will be as the configuration could become large over time.
+CDK_CONTEXT_PARAMS_VAR: str = "ARKIME_PARAMS"
+
 # The context key that the CDK App is looking for to know if the user specified an AWS region different than the one
 # associated with their AWS Credential profile
 CDK_CONTEXT_REGION_VAR: str = "ARKIME_REGION"
 
-# The names of CDK Stacks defined in our App
+# The names of the management operations we can perform; will be received/parsed on the CDK side so needs to match.
+CMD_DEPLOY_DEMO = "DeployDemoTraffic"
+CMD_DESTROY_DEMO = "DestroyDemoTraffic"
+CMD_CREATE_CLUSTER = "CreateCluster"
+
+# The names of static CDK Stacks defined in our App
 NAME_DEMO_STACK_1: str = "DemoTrafficGen01"
 NAME_DEMO_STACK_2: str = "DemoTrafficGen02"
+
+# Static type names for our various stacks
+STACK_TYPE_CAPTURE_VPC = "CaptureVpcStack"
+
+# =================================================================================================
+# These stack names cross the boundary between the Python and CDK sides of the solution, but are not hardcoded on the
+# CDK side as well.  They are defined on the Python side because we need to know in-Python the names of the CDK stacks
+# we want to manipulate.
+# =================================================================================================
+def get_capture_vpc_stack_name(cluster_name: str) -> str:
+    return f"{cluster_name}-CaptureVPC"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/test_manage_arkime/test_cdk_exceptions.py
+++ b/test_manage_arkime/test_cdk_exceptions.py
@@ -100,7 +100,7 @@ def test_WHEN_signature_mismatch_THEN_raises():
     with pytest.raises(exceptions.CommonAWSCredentialsSigMismatch):
         exceptions.raise_common_exceptions(exit_code, stdout)
 
-def test_WHEN_not_bootstrapped_stack_THEN_raises():
+def test_WHEN_not_bootstrapped_stack_THEN_raises_1():
     # Set up our mock
     exit_code = 1
     stdout = [
@@ -116,6 +116,22 @@ def test_WHEN_not_bootstrapped_stack_THEN_raises():
         "",
         "Building Assets Failed: Error: MyStack: SSM parameter /cdk-bootstrap/blah/version not found. Has the environment been bootstrapped? Please run 'cdk bootstrap' (see https://docs.aws.amazon.com/cdk/latest/guide/bootstrapping.html)"
     ]
+
+    # Run our test
+    with pytest.raises(exceptions.CommonCdkNotBootstrapped):
+        exceptions.raise_common_exceptions(exit_code, stdout)
+
+def test_WHEN_not_bootstrapped_stack_THEN_raises_2():
+    # Set up our mock
+    exit_code = 1
+    raw_stdout = """
+    [0%] start: Building da93f9fd3c42d618a322361a988afe52bdd76e6b284c1b2dbfadd7e063fe24df:XXXXXXXXXXXX-us-east-2
+    [0%] start: Building ed75578691729c241bb3f8fb32c6e68b317241e63c3ab33684c92f69ab66c9fc:XXXXXXXXXXXX-us-east-2
+    [50%] success: Built da93f9fd3c42d618a322361a988afe52bdd76e6b284c1b2dbfadd7e063fe24df:XXXXXXXXXXXX-us-east-2
+    [100%] fail: No ECR repository named 'cdk-hnb659fds-container-assets-XXXXXXXXXXXX-us-east-2' in account XXXXXXXXXXXX. Is this account bootstrapped?
+    """
+
+    stdout = raw_stdout.split("\n")
 
     # Run our test
     with pytest.raises(exceptions.CommonCdkNotBootstrapped):

--- a/test_manage_arkime/test_create_cluster.py
+++ b/test_manage_arkime/test_create_cluster.py
@@ -1,0 +1,31 @@
+import json
+import shlex
+import unittest.mock as mock
+
+from manage_arkime.commands.create_cluster import cmd_create_cluster
+import manage_arkime.constants as constants
+
+@mock.patch("manage_arkime.commands.create_cluster.CdkClient")
+def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls):
+    # Set up our mock
+    mock_client = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_client
+
+    # Run our test
+    cmd_create_cluster("profile", "region", "my-cluster")
+
+    # Check our results
+    expected_calls = [
+        mock.call(
+            [constants.get_capture_vpc_stack_name("my-cluster")],
+            aws_profile="profile",
+            aws_region="region",
+            context={
+                constants.CDK_CONTEXT_CMD_VAR: constants.CMD_CREATE_CLUSTER,
+                constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps({
+                    "nameCaptureVpc": constants.get_capture_vpc_stack_name("my-cluster")
+                }))
+            }
+        )
+    ]
+    assert expected_calls == mock_client.deploy.call_args_list

--- a/test_manage_arkime/test_deploy_demo_traffic.py
+++ b/test_manage_arkime/test_deploy_demo_traffic.py
@@ -1,0 +1,24 @@
+import unittest.mock as mock
+
+from manage_arkime.commands.deploy_demo_traffic import cmd_deploy_demo_traffic
+import manage_arkime.constants as constants
+
+@mock.patch("manage_arkime.commands.deploy_demo_traffic.CdkClient")
+def test_WHEN_cmd_deploy_demo_traffic_called_THEN_cdk_command_correct(mock_cdk_client_cls):
+    # Set up our mock
+    mock_client = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_client
+
+    # Run our test
+    cmd_deploy_demo_traffic("profile", "region")
+
+    # Check our results
+    expected_calls = [
+        mock.call(
+            [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2],
+            aws_profile="profile",
+            aws_region="region",
+            context={constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DEPLOY_DEMO}
+        )
+    ]
+    assert expected_calls == mock_client.deploy.call_args_list

--- a/test_manage_arkime/test_destroy_demo_traffic.py
+++ b/test_manage_arkime/test_destroy_demo_traffic.py
@@ -1,0 +1,24 @@
+import unittest.mock as mock
+
+from manage_arkime.commands.destroy_demo_traffic import cmd_destroy_demo_traffic
+import manage_arkime.constants as constants
+
+@mock.patch("manage_arkime.commands.destroy_demo_traffic.CdkClient")
+def test_WHEN_cmd_destroy_demo_traffic_called_THEN_cdk_command_correct(mock_cdk_client_cls):
+    # Set up our mock
+    mock_client = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_client
+
+    # Run our test
+    cmd_destroy_demo_traffic("profile", "region")
+
+    # Check our results
+    expected_calls = [
+        mock.call(
+            [constants.NAME_DEMO_STACK_1, constants.NAME_DEMO_STACK_2],
+            aws_profile="profile",
+            aws_region="region",
+            context={constants.CDK_CONTEXT_CMD_VAR: constants.CMD_DESTROY_DEMO}
+        )
+    ]
+    assert expected_calls == mock_client.destroy.call_args_list


### PR DESCRIPTION
## Description

At a high level: 
* Created a mechanism for passing configuration details from Python to CDK using CDK Context
* Added a new, partially implemented command for creating a Cluster
* Enabled ECS Exec in our Fargate containers so they can be shelled into

This PR should show the direction this code is going.  There's a core issue with wrapping the CDK in Python like this that the CDK usually serves as the sole source of truth for application infrastructure state.  However, because we're just using it for infrastructure definition and spinnup/teardown, the Python side needs to track the state and pass it into the CDK via CDK Context.

I struggled a bit with how to handle this but I'm pretty sure this approach is viable.  We may run into some issues once we have complex setups we need to track and pass into the CDK (e.g. a Capture VPC, Viewer VPC, an OpenSearch Cluster, and many traffic mirroring setups targeting many user VPCs).  

On another note, I'm not great at TypeScript so there may be better ways to do things on that side (especially the interface definition/type checking).

## Testing
* Added/updated some unit tests on the Python side
* Unit testing on the TypeScript side is lacking, will add in a future commit
* Manually tested the CLI operations:

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py create-cluster --name MyCluster
2023-03-29 22:04:48 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-03-29 22:04:48 - Using AWS Credential Profile: default
2023-03-29 22:04:48 - Using AWS Region: default from AWS Config settings
2023-03-29 22:04:48 - Executing command: deploy MyCluster-CaptureVPC
2023-03-29 22:04:48 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-03-29 22:05:56 - Deployment succeeded
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py destroy-demo-traffic
2023-03-29 22:10:17 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-03-29 22:10:17 - Using AWS Credential Profile: default
2023-03-29 22:10:17 - Using AWS Region: default from AWS Config settings
2023-03-29 22:10:17 - Found credentials in shared credentials file: ~/.aws/credentials
2023-03-29 22:10:18 - ================================================================================
2023-03-29 22:10:18 - USER ACTION REQUIRED:
2023-03-29 22:10:18 - --------------------------------------------------------------------------------
Your command will result in the the following CloudFormation stacks being destroyed in AWS Account XXXXXXXXXXXX and Region us-east-2: ['DemoTrafficGen01', 'DemoTrafficGen02']

Do you wish to proceed (y/yes or n/no)? yes
2023-03-29 22:10:23 - Executing command: destroy --force DemoTrafficGen01 DemoTrafficGen02
2023-03-29 22:10:23 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-03-29 22:13:48 - Destruction succeeded
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py deploy-demo-traffic
2023-03-29 22:14:01 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-03-29 22:14:01 - Using AWS Credential Profile: default
2023-03-29 22:14:01 - Using AWS Region: default from AWS Config settings
2023-03-29 22:14:01 - Executing command: deploy DemoTrafficGen01 DemoTrafficGen02
2023-03-29 22:14:01 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-03-29 22:20:44 - Deployment succeeded
```