### PR TITLE
Made the VNI configurable for each monitored VPC

### DIFF
--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -76,7 +76,8 @@ switch(params.type) {
             subnetSsmParamNames: params.listSubnetSsmParams,
             vpcId: params.idVpc,
             vpcSsmParamName: params.nameVpcSsmParam,
-            vpceServiceId: params.idVpceService
+            vpceServiceId: params.idVpceService,
+            mirrorVni: params.idVni
         })
         break;
     case 'DeployDemoTrafficParams':

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -31,6 +31,7 @@ export interface MirrorMgmtParamsRaw extends CommandParamsRaw {
     type: 'MirrorMgmtParamsRaw';
     nameVpcMirrorStack: string;
     nameVpcSsmParam: string;
+    idVni: string;
     idVpc: string;
     idVpceService: string;
     listSubnetIds: string[];
@@ -89,6 +90,7 @@ export interface MirrorMgmtParams extends CommandParams {
     type: 'MirrorMgmtParams';
     nameVpcMirrorStack: string;
     nameVpcSsmParam: string;
+    idVni: string;
     idVpc: string;
     idVpceService: string;
     listSubnetIds: string[];

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -114,6 +114,7 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 awsRegion: args.awsRegion,
                 nameVpcMirrorStack: rawMirrorMgmtParamsObj.nameVpcMirrorStack,
                 nameVpcSsmParam: rawMirrorMgmtParamsObj.nameVpcSsmParam,
+                idVni: rawMirrorMgmtParamsObj.idVni,
                 idVpc: rawMirrorMgmtParamsObj.idVpc,
                 idVpceService: rawMirrorMgmtParamsObj.idVpceService,
                 listSubnetIds: rawMirrorMgmtParamsObj.listSubnetIds,

--- a/cdk-lib/core/ssm-wrangling.ts
+++ b/cdk-lib/core/ssm-wrangling.ts
@@ -17,5 +17,6 @@ export interface SubnetSsmValue {
 
 export interface VpcSsmValue {
     readonly mirrorFilterId: string;
+    readonly mirrorVni: string;
     readonly vpcId: string;
 }

--- a/cdk-lib/mirror-stacks/vpc-mirror-stack.ts
+++ b/cdk-lib/mirror-stacks/vpc-mirror-stack.ts
@@ -13,6 +13,7 @@ export interface VpcMirrorStackProps extends StackProps {
     readonly vpcId: string;
     readonly vpcSsmParamName: string;
     readonly vpceServiceId: string;
+    readonly mirrorVni: string;
 }
 
 /**
@@ -107,7 +108,7 @@ export class VpcMirrorStack extends Stack {
         });
 
         // This SSM parameter will enable us share the details of our VPC-specific Capture setup
-        const vpcParamValue: VpcSsmValue = {mirrorFilterId: filter.ref, vpcId: props.vpcId}
+        const vpcParamValue: VpcSsmValue = {mirrorFilterId: filter.ref, mirrorVni: props.mirrorVni, vpcId: props.vpcId}
         const vpcParam = new ssm.StringParameter(this, `VpcParam-${props.vpcId}`, {
             allowedPattern: '.*',
             description: 'The VPC\'s details',

--- a/cdk-lib/mirror-stacks/vpc-mirror-stack.ts
+++ b/cdk-lib/mirror-stacks/vpc-mirror-stack.ts
@@ -67,7 +67,8 @@ export class VpcMirrorStack extends Stack {
         // Let's mirror all non-local VPC traffic
         // See: https://docs.aws.amazon.com/vpc/latest/mirroring/tm-example-non-vpc.html
         const filter = new ec2.CfnTrafficMirrorFilter(this, `Filter`, {
-            description: 'Mirror non-local VPC traffic'
+            description: 'Mirror non-local VPC traffic',
+            tags: [{key: "Name", value: props.vpcId}]
         });
         new ec2.CfnTrafficMirrorFilterRule(this, `FRule-RejectLocalOutbound`, {
             destinationCidrBlock: '10.0.0.0/16', // TODO: Need to figure this out instead of hardcode

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -11,6 +11,7 @@ from manage_arkime.commands.destroy_demo_traffic import cmd_destroy_demo_traffic
 from manage_arkime.commands.get_login_details import cmd_get_login_details
 from manage_arkime.commands.list_clusters import cmd_list_clusters
 from manage_arkime.commands.remove_vpc import cmd_remove_vpc
+import manage_arkime.constants as constants
 from manage_arkime.logging_wrangler import LoggingWrangler
 
 logger = logging.getLogger(__name__)
@@ -96,11 +97,13 @@ cli.add_command(list_clusters)
 @click.command(help="Sets up the specified VPC to have its traffic monitored by the specified, existing Arkime Cluster")
 @click.option("--cluster-name", help="The name of the Arkime Cluster to monitor with", required=True)
 @click.option("--vpc-id", help="The VPC ID to begin monitoring.  Must be in the same account/region as the Cluster.", required=True)
+@click.option("--vni", help="The Virtual Network Interface ID (24-bit int) to assign to the VPC.  Can be used to uniquely identify the VPC on the capture side.",
+        default=constants.VNI_DEFAULT, type=int)
 @click.pass_context
-def add_vpc(ctx, cluster_name, vpc_id):
+def add_vpc(ctx, cluster_name, vpc_id, vni):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_add_vpc(profile, region, cluster_name, vpc_id)
+    cmd_add_vpc(profile, region, cluster_name, vpc_id, vni)
 cli.add_command(add_vpc)
 
 @click.command(help="Removes traffic monitoring from the specified VPC being performed by the specified Arkime Cluster")

--- a/manage_arkime/commands/add_vpc.py
+++ b/manage_arkime/commands/add_vpc.py
@@ -10,25 +10,31 @@ import manage_arkime.cdk_context as context
 
 logger = logging.getLogger(__name__)
 
-def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
+def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, vni: int):
     logger.debug(f"Invoking add-vpc with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
+
+    # Confirm the VNI is valid
+    if (vni <= constants.VNI_MIN) or (constants.VNI_MAX < vni):
+        logger.error(f"VNI {vni} is outside the acceptable range of {constants.VNI_MIN} to {constants.VNI_MAX} (inclusive)")
+        logger.warning("Aborting...")
+        return
 
     # Confirm the Cluster exists before proceeding
     try:
         ssm_ops.get_ssm_param_value(constants.get_cluster_ssm_param_name(cluster_name), aws_provider)
     except ssm_ops.ParamDoesNotExist:
-        logger.warning(f"The cluster {cluster_name} does not exist; try using the list-clusters command to see the clusters you have created.")
-        logger.warning("Aborting operation...")
+        logger.error(f"The cluster {cluster_name} does not exist; try using the list-clusters command to see the clusters you have created.")
+        logger.warning("Aborting...")
         return
 
     # Get all the subnets in the VPC
     try:
         subnet_ids = ec2i.get_subnets_of_vpc(vpc_id, aws_provider)
     except ec2i.VpcDoesNotExist as ex:
-        logger.warning(f"The VPC {vpc_id} does not exist in the account/region")
-        logger.warning("Aborting operation...")
+        logger.error(f"The VPC {vpc_id} does not exist in the account/region")
+        logger.warning("Aborting...")
         return
 
     # Get the VPCE Service ID we set up with our Capture VPC
@@ -39,7 +45,7 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
     stacks_to_deploy = [
         constants.get_vpc_mirror_setup_stack_name(cluster_name, vpc_id)
     ]
-    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id)
+    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, vni)
 
     cdk_client = CdkClient()
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=add_vpc_context)
@@ -57,9 +63,9 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
     traffic_filter_id = ssm_ops.get_ssm_param_json_value(vpc_param_name, "mirrorFilterId", aws_provider)
     
     for subnet_id in subnet_ids:
-        _mirror_enis_in_subnet(cluster_name, vpc_id, subnet_id, traffic_filter_id, aws_provider)
+        _mirror_enis_in_subnet(cluster_name, vpc_id, subnet_id, traffic_filter_id, vni, aws_provider)
 
-def _mirror_enis_in_subnet(cluster_name: str, vpc_id: str, subnet_id: str, traffic_filter_id: str, aws_provider: AwsClientProvider):
+def _mirror_enis_in_subnet(cluster_name: str, vpc_id: str, subnet_id: str, traffic_filter_id: str, vni: int, aws_provider: AwsClientProvider):
     enis = ec2i.get_enis_of_subnet(subnet_id, aws_provider)
 
     for eni in enis:
@@ -83,7 +89,7 @@ def _mirror_enis_in_subnet(cluster_name: str, vpc_id: str, subnet_id: str, traff
                 traffic_target_id,
                 traffic_filter_id,
                 aws_provider,
-                virtual_network=123
+                virtual_network=vni
             )
         except ec2i.NonMirrorableEniType as ex:
             logger.info(f"Eni {eni.id} is of unsupported type {eni.type}; skipping")

--- a/manage_arkime/commands/add_vpc.py
+++ b/manage_arkime/commands/add_vpc.py
@@ -88,6 +88,7 @@ def _mirror_enis_in_subnet(cluster_name: str, vpc_id: str, subnet_id: str, traff
                 eni,
                 traffic_target_id,
                 traffic_filter_id,
+                vpc_id,
                 aws_provider,
                 virtual_network=vni
             )

--- a/manage_arkime/commands/destroy_cluster.py
+++ b/manage_arkime/commands/destroy_cluster.py
@@ -18,7 +18,7 @@ def cmd_destroy_cluster(profile: str, region: str, name: str, destroy_everything
     vpcs_search_path = f"{constants.get_cluster_ssm_param_name(name)}/vpcs"
     monitored_vpcs = get_ssm_names_by_path(vpcs_search_path, aws_provider)
     if monitored_vpcs:
-        logger.warning("Your cluster is currently monitoring VPCs.  Please stop monitoring these VPCs using the"
+        logger.error("Your cluster is currently monitoring VPCs.  Please stop monitoring these VPCs using the"
             + f" remove-vpc command before destroying your cluster:\n{monitored_vpcs}")
         logger.warning("Aborting...")
         return

--- a/manage_arkime/commands/list_clusters.py
+++ b/manage_arkime/commands/list_clusters.py
@@ -18,9 +18,18 @@ def cmd_list_clusters(profile: str, region: str) -> List[Dict[str, str]]:
     for cluster_name in cluster_names:
         ssm_vpcs_path_prefix = f"{constants.get_cluster_ssm_param_name(cluster_name)}/vpcs"
         vpc_ids = ssm_ops.get_ssm_names_by_path(ssm_vpcs_path_prefix, aws_provider)
+        vpc_details = []
+        for vpc_id in vpc_ids:
+            vpc_ssm_param = constants.get_vpc_ssm_param_name(cluster_name, vpc_id)
+            vni = ssm_ops.get_ssm_param_json_value(vpc_ssm_param, "mirrorVni", aws_provider)
+            vpc_details.append({
+                "vpc_id": vpc_id,
+                "vni": vni,
+            })
+
         cluster_details.append({
             "cluster_name": cluster_name,
-            "monitored_vpcs": vpc_ids
+            "monitored_vpcs": vpc_details
         })
 
     formatted_details = json.dumps(cluster_details, indent=4)

--- a/manage_arkime/commands/remove_vpc.py
+++ b/manage_arkime/commands/remove_vpc.py
@@ -23,8 +23,8 @@ def cmd_remove_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
     try:
         vpce_service_id = ssm_ops.get_ssm_param_json_value(constants.get_cluster_ssm_param_name(cluster_name), "vpceServiceId", aws_provider)
     except ssm_ops.ParamDoesNotExist:
-        logger.warning(f"The cluster {cluster_name} does not exist; try using the list-clusters command to see the clusters you have created.")
-        logger.warning("Aborting operation...")
+        logger.error(f"The cluster {cluster_name} does not exist; try using the list-clusters command to see the clusters you have created.")
+        logger.warning("Aborting...")
         return
 
     # Pull all our deployed configuration from SSM and tear down the ENI-specific resources

--- a/manage_arkime/constants.py
+++ b/manage_arkime/constants.py
@@ -80,3 +80,11 @@ def get_vpc_mirror_setup_stack_name(cluster_name: str, vpc_id: str) -> str:
 
 def get_vpc_ssm_param_name(cluster_name: str, vpc_id: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vpcs/{vpc_id}"
+
+# =================================================================================================
+# These constants are only used on the Python side of the solution.
+# =================================================================================================
+
+VNI_DEFAULT = 123
+VNI_MIN = 1 # 0 is reserved for the default network segment
+VNI_MAX = 16777215 # 2^24 - 1

--- a/test_manage_arkime/test_add_vpc.py
+++ b/test_manage_arkime/test_add_vpc.py
@@ -33,6 +33,7 @@ def test_WHEN_mirror_enis_in_subnet_called_THEN_sets_up_mirroring(mock_ec2i, moc
             eni_1,
             "target-1",
             "filter-1",
+            "vpc-1",
             mock.ANY,
             virtual_network=1234
         ),
@@ -40,6 +41,7 @@ def test_WHEN_mirror_enis_in_subnet_called_THEN_sets_up_mirroring(mock_ec2i, moc
             eni_2,
             "target-1",
             "filter-1",
+            "vpc-1",
             mock.ANY,
             virtual_network=1234
         ),
@@ -94,6 +96,7 @@ def test_WHEN_mirror_enis_in_subnet_called_AND_already_mirrored_THEN_skips(mock_
             eni_1,
             "target-1",
             "filter-1",
+            "vpc-1",
             mock.ANY,
             virtual_network=1234
         )

--- a/test_manage_arkime/test_ec2_interactions.py
+++ b/test_manage_arkime/test_ec2_interactions.py
@@ -123,7 +123,7 @@ def test_WHEN_mirror_eni_called_THEN_sets_up_session():
 
     # Run our test
     test_eni = ec2i.NetworkInterface("eni-1", "type-1")
-    result = ec2i.mirror_eni(test_eni, "target-1", "filter-1", mock_aws_provider, virtual_network=1234)
+    result = ec2i.mirror_eni(test_eni, "target-1", "filter-1", "vpc-1", mock_aws_provider, virtual_network=1234)
 
     # Check our results
     expected_create_calls = [
@@ -132,7 +132,18 @@ def test_WHEN_mirror_eni_called_THEN_sets_up_session():
             TrafficMirrorTargetId="target-1",
             TrafficMirrorFilterId="filter-1",
             SessionNumber=1,
-            VirtualNetworkId=1234
+            VirtualNetworkId=1234,
+            TagSpecifications=[
+                {
+                    "ResourceType": "traffic-mirror-session",
+                    "Tags": [
+                        {
+                            "Key": "Name",
+                            "Value": "vpc-1-eni-1"
+                        },
+                    ]
+                },
+            ],
         )
     ]
     assert expected_create_calls == mock_ec2_client.create_traffic_mirror_session.call_args_list
@@ -149,7 +160,7 @@ def test_WHEN_mirror_eni_called_AND_excluded_type_THEN_raises():
     # Run our test
     test_eni = ec2i.NetworkInterface("eni-1", ec2i.NON_MIRRORABLE_ENI_TYPES[0])
     with pytest.raises(ec2i.NonMirrorableEniType):
-        ec2i.mirror_eni(test_eni, "target-1", "filter-1", mock_aws_provider, virtual_network=1234)
+        ec2i.mirror_eni(test_eni, "target-1", "filter-1", "vpc-1", mock_aws_provider, virtual_network=1234)
 
     # Check our results
     expected_create_calls = []

--- a/test_manage_arkime/test_list_clusters.py
+++ b/test_manage_arkime/test_list_clusters.py
@@ -7,6 +7,8 @@ import manage_arkime.constants as constants
 @mock.patch("manage_arkime.commands.list_clusters.ssm_ops")
 def test_WHEN_cmd_list_clusters_called_THEN_lists_them(mock_ssm_ops):
     # Set up our mock
+    mock_ssm_ops.get_ssm_param_json_value.side_effect = ["vni-1", "vni-2", "vni-3"]
+
     mock_ssm_ops.get_ssm_names_by_path.side_effect = [
         ["cluster-1", "cluster-2"],
         ["vpc-1", "vpc-2"],
@@ -25,8 +27,19 @@ def test_WHEN_cmd_list_clusters_called_THEN_lists_them(mock_ssm_ops):
     assert expected_get_names_calls == mock_ssm_ops.get_ssm_names_by_path.call_args_list
 
     expected_result = [
-        {"cluster_name": "cluster-1", "monitored_vpcs": ["vpc-1", "vpc-2"]},
-        {"cluster_name": "cluster-2", "monitored_vpcs": ["vpc-3"]}
+        {
+            "cluster_name": "cluster-1", 
+            "monitored_vpcs": [
+                {"vpc_id": "vpc-1", "vni": "vni-1"},
+                {"vpc_id": "vpc-2", "vni": "vni-2"}
+            ]
+        },
+        {
+            "cluster_name": "cluster-2", 
+            "monitored_vpcs": [
+                {"vpc_id": "vpc-3", "vni": "vni-3"}
+            ]
+        }
     ]
     assert expected_result == result
 

--- a/test_manage_arkime/test_remove_vpc.py
+++ b/test_manage_arkime/test_remove_vpc.py
@@ -94,6 +94,7 @@ def test_WHEN_cmd_remove_vpc_called_THEN_sets_up_mirroring(mock_cdk_client_cls, 
                 constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps({
                     "nameVpcMirrorStack": constants.get_vpc_mirror_setup_stack_name("cluster-1", "vpc-1"),
                     "nameVpcSsmParam": constants.get_vpc_ssm_param_name("cluster-1", "vpc-1"),
+                    "idVni": str(constants.VNI_DEFAULT),
                     "idVpc": "vpc-1",
                     "idVpceService": "service-1",
                     "listSubnetIds": ["subnet-1", "subnet-2"],


### PR DESCRIPTION
## Description
* `add-vpc` now allows user to set the Virtual Network Identifier associated with each VPC Traffic Mirroring Session associated with it.  This enables the user to identify traffic specific to that VPC.  If the user does not specify a VNI, a default value is applied.
* `list-clusters` now reports the VNI for each monitored VPC.

## Tasks
* https://github.com/arkime/cloud-demo/issues/21

## Testing
* Added unit tests
* Ran the command against my AWS Account:

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py list-clusters
2023-04-20 13:07:40 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-20 13:07:40 - Using AWS Credential Profile: default
2023-04-20 13:07:40 - Using AWS Region: default from AWS Config settings
2023-04-20 13:07:40 - Retrieving cluster details...
2023-04-20 13:07:40 - Pulling SSM Parameters for Path /arkime/clusters...
2023-04-20 13:07:40 - Pulling SSM Parameters for Path /arkime/clusters/MyCluster/vpcs...
2023-04-20 13:07:41 - Pulling SSM Parameter /arkime/clusters/MyCluster/vpcs/vpc-003a3436126a5a140...
2023-04-20 13:07:41 - Pulling SSM Parameters for Path /arkime/clusters/MyCluster2/vpcs...
2023-04-20 13:07:42 - Pulling SSM Parameters for Path /arkime/clusters/MyCluster3/vpcs...
2023-04-20 13:07:42 - Pulling SSM Parameter /arkime/clusters/MyCluster3/vpcs/vpc-085d9c6085d49263e...
2023-04-20 13:07:42 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-003a3436126a5a140",
                "vni": "42"
            }
        ]
    },
    {
        "cluster_name": "MyCluster2",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-085d9c6085d49263e",
                "vni": "1337"
            }
        ]
    }
]
```