### PR TITLE
add-vpc now auto-selects an available VNI

### DIFF
--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -94,16 +94,19 @@ def list_clusters(ctx):
     cmd_list_clusters(profile, region)
 cli.add_command(list_clusters)
 
-@click.command(help="Sets up the specified VPC to have its traffic monitored by the specified, existing Arkime Cluster")
+@click.command(help=("Sets up the specified VPC to have its traffic monitored by the specified, existing Arkime Cluster."
+                    + "  By default, each VPC is assigned a Virtual Network Interface ID (VNI) unused by any other VPC"
+                    + f" in the Cluster to uniquely identify it.  The starting default value is {constants.VNI_MIN}."))
 @click.option("--cluster-name", help="The name of the Arkime Cluster to monitor with", required=True)
 @click.option("--vpc-id", help="The VPC ID to begin monitoring.  Must be in the same account/region as the Cluster.", required=True)
-@click.option("--vni", help="The Virtual Network Interface ID (24-bit int) to assign to the VPC.  Can be used to uniquely identify the VPC on the capture side.",
-        default=None, type=int)
+@click.option("--force-vni", help=("POWER USER OPTION.  Forcefully assign the VPC to use a specific VNI.  This can"
+              + " result in multiple VPCs using the same VNI, and VNIs to potentially be re-used long after they are"
+              + " relinquished."), default=None, type=int)
 @click.pass_context
-def add_vpc(ctx, cluster_name, vpc_id, vni):
+def add_vpc(ctx, cluster_name, vpc_id, force_vni):
     profile = ctx.obj.get("profile")
     region = ctx.obj.get("region")
-    cmd_add_vpc(profile, region, cluster_name, vpc_id, vni)
+    cmd_add_vpc(profile, region, cluster_name, vpc_id, force_vni)
 cli.add_command(add_vpc)
 
 @click.command(help="Removes traffic monitoring from the specified VPC being performed by the specified Arkime Cluster")

--- a/manage_arkime.py
+++ b/manage_arkime.py
@@ -98,7 +98,7 @@ cli.add_command(list_clusters)
 @click.option("--cluster-name", help="The name of the Arkime Cluster to monitor with", required=True)
 @click.option("--vpc-id", help="The VPC ID to begin monitoring.  Must be in the same account/region as the Cluster.", required=True)
 @click.option("--vni", help="The Virtual Network Interface ID (24-bit int) to assign to the VPC.  Can be used to uniquely identify the VPC on the capture side.",
-        default=constants.VNI_DEFAULT, type=int)
+        default=None, type=int)
 @click.pass_context
 def add_vpc(ctx, cluster_name, vpc_id, vni):
     profile = ctx.obj.get("profile")

--- a/manage_arkime/aws_interactions/ssm_operations.py
+++ b/manage_arkime/aws_interactions/ssm_operations.py
@@ -53,7 +53,8 @@ def get_ssm_names_by_path(param_path: str, aws_client_provider: AwsClientProvide
     raw_params = get_ssm_params_by_path(param_path, aws_client_provider)
     return [param["Name"].split("/")[-1] for param in raw_params]
 
-def put_ssm_param(param_name: str, param_value: str, aws_client_provider: AwsClientProvider, description: str = None, pattern: str = None):
+def put_ssm_param(param_name: str, param_value: str, aws_client_provider: AwsClientProvider, description: str = None, 
+        pattern: str = None, overwrite=False):
     ssm_client = aws_client_provider.get_ssm()
 
     ssm_client.put_parameter(
@@ -63,6 +64,7 @@ def put_ssm_param(param_name: str, param_value: str, aws_client_provider: AwsCli
         Type="String",
         AllowedPattern=".*",
         Tier='Standard',
+        Overwrite=overwrite
     )
 
 def delete_ssm_param(param_name: str, aws_client_provider: AwsClientProvider):

--- a/manage_arkime/commands/add_vpc.py
+++ b/manage_arkime/commands/add_vpc.py
@@ -7,17 +7,40 @@ import aws_interactions.ssm_operations as ssm_ops
 from manage_arkime.cdk_client import CdkClient
 import manage_arkime.constants as constants
 import manage_arkime.cdk_context as context
+from manage_arkime.vni_provider import SsmVniProvider, VniAlreadyUsed, VniOutsideRange, VniPoolExhausted
 
 logger = logging.getLogger(__name__)
 
-def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, vni: int):
+def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, user_vni: int):
     logger.debug(f"Invoking add-vpc with profile '{profile}' and region '{region}'")
 
     aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
+    vni_provider = SsmVniProvider(cluster_name, aws_provider)
 
-    # Confirm the VNI is valid
-    if (vni <= constants.VNI_MIN) or (constants.VNI_MAX < vni):
-        logger.error(f"VNI {vni} is outside the acceptable range of {constants.VNI_MIN} to {constants.VNI_MAX} (inclusive)")
+    # If the user didn't supply a VNI, try to find one
+    if not user_vni:
+        try:
+            next_vni = vni_provider.get_next_vni()
+        except VniPoolExhausted:
+            logger.error(f"There are no remaining VNIs in the range {constants.VNI_MIN} to {constants.VNI_MAX} to assign for this cluster")
+            logger.warning("Aborting...")
+            return
+
+    # Confirm the user-supplied VNI is available
+    try:
+        if user_vni and not vni_provider.is_vni_available(user_vni):
+            logger.error(f"VNI {user_vni} is already in use and cannot be used again.  Use list-clusters to see the VNIs"
+                           + " assigned to your clusters.")
+            logger.warning("Aborting...")
+            return
+        elif user_vni:
+            next_vni = user_vni
+    except VniAlreadyUsed:
+        logger.error(f"VNI {user_vni} is already in use; you can use the list-clusters command to see which VPC it is assigned to.")
+        logger.warning("Aborting...")
+        return
+    except VniOutsideRange:
+        logger.error(f"VNI {user_vni} is outside the acceptable range of {constants.VNI_MIN} to {constants.VNI_MAX} (inclusive)")
         logger.warning("Aborting...")
         return
 
@@ -45,7 +68,7 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, vni: 
     stacks_to_deploy = [
         constants.get_vpc_mirror_setup_stack_name(cluster_name, vpc_id)
     ]
-    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, vni)
+    add_vpc_context = context.generate_add_vpc_context(cluster_name, vpc_id, subnet_ids, vpce_service_id, next_vni)
 
     cdk_client = CdkClient()
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=add_vpc_context)
@@ -63,7 +86,14 @@ def cmd_add_vpc(profile: str, region: str, cluster_name: str, vpc_id: str, vni: 
     traffic_filter_id = ssm_ops.get_ssm_param_json_value(vpc_param_name, "mirrorFilterId", aws_provider)
     
     for subnet_id in subnet_ids:
-        _mirror_enis_in_subnet(cluster_name, vpc_id, subnet_id, traffic_filter_id, vni, aws_provider)
+        _mirror_enis_in_subnet(cluster_name, vpc_id, subnet_id, traffic_filter_id, next_vni, aws_provider)
+
+    # Register the VNI as used.  The VNI's usage is tied to the ENI-specific configuration, so we perform this
+    # after that is set up.
+    if user_vni:
+        vni_provider.register_user_vni(next_vni)
+    else:
+        vni_provider.use_next_vni(next_vni)
 
 def _mirror_enis_in_subnet(cluster_name: str, vpc_id: str, subnet_id: str, traffic_filter_id: str, vni: int, aws_provider: AwsClientProvider):
     enis = ec2i.get_enis_of_subnet(subnet_id, aws_provider)

--- a/manage_arkime/commands/remove_vpc.py
+++ b/manage_arkime/commands/remove_vpc.py
@@ -45,7 +45,7 @@ def cmd_remove_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
     # AWS resources rather than the CDK-generated ones, so we perform this before our CDK operation in case it fails.
     vpc_vni = ssm_ops.get_ssm_param_json_value(vpc_ssm_param, "mirrorVni", aws_provider)
     vni_provider = SsmVniProvider(cluster_name, aws_provider)
-    vni_provider.relinquish_vni(int(vpc_vni))
+    vni_provider.relinquish_vni(int(vpc_vni), vpc_id)
 
     # Destroy the VPC-specific mirroring components in CloudFormation
     logger.info("Tearing down shared mirroring components via CDK...")
@@ -56,9 +56,6 @@ def cmd_remove_vpc(profile: str, region: str, cluster_name: str, vpc_id: str):
 
     cdk_client = CdkClient()
     cdk_client.destroy(stacks_to_destroy, aws_profile=profile, aws_region=region, context=add_vpc_context)
-
-
-
 
 def _remove_mirroring_for_eni(cluster_name: str, vpc_id: str, subnet_id: str, eni_id: str, aws_provider: AwsClientProvider):
     eni_param = constants.get_eni_ssm_param_name(cluster_name, vpc_id, subnet_id, eni_id)

--- a/manage_arkime/constants.py
+++ b/manage_arkime/constants.py
@@ -51,9 +51,6 @@ def get_capture_vpc_stack_name(cluster_name: str) -> str:
 def get_cluster_ssm_param_name(cluster_name: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}"
 
-def get_eni_ssm_param_name(cluster_name: str, vpc_id: str, subnet_id: str, eni_id) -> str:
-    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vpcs/{vpc_id}/subnets/{subnet_id}/enis/{eni_id}"
-
 def get_opensearch_domain_stack_name(cluster_name: str) -> str:
     return f"{cluster_name}-OSDomain"
 
@@ -85,6 +82,18 @@ def get_vpc_ssm_param_name(cluster_name: str, vpc_id: str) -> str:
 # These constants are only used on the Python side of the solution.
 # =================================================================================================
 
+def get_eni_ssm_param_name(cluster_name: str, vpc_id: str, subnet_id: str, eni_id: str) -> str:
+    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vpcs/{vpc_id}/subnets/{subnet_id}/enis/{eni_id}"
+
 VNI_DEFAULT = 123
 VNI_MIN = 1 # 0 is reserved for the default network segment
 VNI_MAX = 16777215 # 2^24 - 1
+
+def get_vnis_recycled_ssm_param_name(cluster_name: str) -> str:
+    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vnis-recycled"
+
+def get_vnis_user_ssm_param_name(cluster_name: str) -> str:
+    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vnis-user"
+
+def get_vni_current_ssm_param_name(cluster_name: str) -> str:
+    return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vni-current"

--- a/manage_arkime/vni_provider.py
+++ b/manage_arkime/vni_provider.py
@@ -1,0 +1,232 @@
+from abc import ABC, abstractmethod
+import json
+import logging
+from typing import List
+
+import manage_arkime.constants as constants
+from manage_arkime.aws_interactions.aws_client_provider import AwsClientProvider
+import manage_arkime.aws_interactions.ssm_operations as ssm_ops
+
+logger = logging.getLogger(__name__)
+
+class VniAlreadyUsed(Exception):
+    def __init__(self, vni: int):
+        self.vni = vni
+        super().__init__(f"The VNI {vni} has already been assigned to a VPC")
+
+class VniOutsideRange(Exception):
+    def __init__(self, vni: int):
+        self.vni = vni
+        super().__init__(f"The VNI {vni} is outside the acceptable range {constants.VNI_MIN}-{constants.VNI_MAX}")
+
+class VniPoolExhausted(Exception):
+    def __init__(self):
+        super().__init__(f"There are no available VNIs in the range {constants.VNI_MIN}-{constants.VNI_MAX}")
+
+"""
+ABC to present a consistent interface for managing the VNIs associated with User VPCs.  The VNI/VPC mappings are unique
+to a given cluster.
+"""
+class VniProvider(ABC):
+    def __init__(self, cluster_name: str):
+        self.cluster_name = cluster_name
+
+    @abstractmethod
+    def get_next_vni(self) -> int:
+        pass
+
+    @abstractmethod
+    def use_next_vni(self, vni: int):
+        pass
+
+    @abstractmethod
+    def register_user_vni(self, vni: int):
+        pass
+
+    @abstractmethod
+    def is_vni_available(self, vni: int):
+        pass
+
+    @abstractmethod
+    def relinquish_vni(self, vni: int):
+        pass
+
+
+"""
+Uses SSM Parameter Store to manage VNI state.
+
+It tracks three different pieces of state:
+* An incrementing integer that allows us to find the next, unused VNI when the user doesn't specify one
+* The list of all VNIs the user specified
+* A list of any previously-relinquished VNIs that we can recycle
+"""
+class SsmVniProvider(VniProvider):
+    def __init__(self, cluster_name: str, aws_provider: AwsClientProvider):
+        super().__init__(cluster_name)
+        self.aws_provider = aws_provider
+
+    """
+    Get the next available VNI that's not already assigned, preferring a recycled one if possible
+    """
+    def get_next_vni(self) -> int:
+        # Use a recycled VNI if possible
+        recycled_vnis = self._get_recycled_vnis()
+        if recycled_vnis:
+            unique_vni = recycled_vnis.pop()
+            return unique_vni
+
+        # Otherwise, get the next unused VNI
+        user_vnis = self._get_user_vnis()
+        current_autogen_vni = self._get_current_autogen_vni()
+        next_vni = current_autogen_vni + 1
+
+        while next_vni in user_vnis:
+            next_vni += 1
+
+        # No more VNIs to choose from, according to the standard
+        if next_vni > constants.VNI_MAX:
+            raise VniPoolExhausted()
+
+        # VNI is valid; return
+        return next_vni
+
+    """
+    Mark a non-user-specified VNI as in-use.  It is expected, but not enforced, that the VNI supplied to this method
+    come from an immediately preceding invocation of get_next_vni()
+    """
+    def use_next_vni(self, vni: int):
+        # Raise if outside acceptable range
+        if (vni < constants.VNI_MIN) or (vni > constants.VNI_MAX):
+            raise VniOutsideRange(vni)
+        
+        # Remove from list of recycled VNIs if it's in there
+        recycled_vnis = self._get_recycled_vnis()
+        if vni in recycled_vnis:
+            recycled_vnis.remove(vni)
+            self._update_recycled_vnis(recycled_vnis)
+
+        # Update our current VNI counter if appropriate
+        current_autogen_vni = self._get_current_autogen_vni()
+        if vni > current_autogen_vni:
+            self._update_current_autogen_vni(vni)
+
+    """
+    Mark a user-specified VNI as in-use, as long as it hasn't already been assigned
+    """
+    def register_user_vni(self, vni: int):
+        # Raise if outside acceptable range
+        if (vni < constants.VNI_MIN) or (vni > constants.VNI_MAX):
+            raise VniOutsideRange(vni)
+
+        # Get existing state
+        recycled_vnis = self._get_recycled_vnis()
+        user_vnis = self._get_user_vnis()
+        current_autogen_vni = self._get_current_autogen_vni()
+
+        # Raise if we've already used this VNI
+        is_recycled = vni in recycled_vnis # Free to re-use
+        is_user_assigned = vni in user_vnis # Collision
+        is_previous_autogen = vni <= current_autogen_vni # Collision
+        if not is_recycled and (is_user_assigned or is_previous_autogen):
+            raise VniAlreadyUsed(vni)
+
+        # Update our list of user VNIs
+        user_vnis.append(vni)
+        self._update_user_vnis(user_vnis)
+
+        # If it was in the recycled list, update that too
+        if is_recycled:
+            recycled_vnis.remove(vni)
+            self._update_recycled_vnis(recycled_vnis)
+
+    def is_vni_available(self, vni: int):
+        # Raise if outside acceptable range
+        if (vni < constants.VNI_MIN) or (vni > constants.VNI_MAX):
+            raise VniOutsideRange(vni)
+
+        recycled_vnis = self._get_recycled_vnis()
+        user_vnis = self._get_user_vnis()
+        current_autogen_vni = self._get_current_autogen_vni()
+
+        is_in_use = (vni in user_vnis) or ((vni <= current_autogen_vni) and vni not in recycled_vnis)
+
+        return not is_in_use
+
+    """
+    Remove a VNI from use.  Remove from the user-specified list if relevant.  Add to list of recycled VNIs if
+    appropriate.
+    """
+    def relinquish_vni(self, vni: int):
+        # Raise if outside acceptable range
+        if (vni < constants.VNI_MIN) or (vni > constants.VNI_MAX):
+            raise VniOutsideRange(vni)
+
+        # Get existing state
+        recycled_vnis = self._get_recycled_vnis()
+        user_vnis = self._get_user_vnis()
+        current_autogen_vni = self._get_current_autogen_vni()
+        
+        # Remove from user-list if in there
+        if vni in user_vnis:
+            user_vnis.remove(vni)
+            self._update_user_vnis(user_vnis)
+
+        # Add to our list of available VNIs if we'd otherwise miss it with auto assignment
+        if (vni >= constants.VNI_MIN) and (vni <= current_autogen_vni):
+            recycled_vnis.append(vni)
+            self._update_recycled_vnis(recycled_vnis)
+
+    def _update_current_autogen_vni(self, new_value: int) -> int:
+        ssm_ops.put_ssm_param(
+            constants.get_vni_current_ssm_param_name(self.cluster_name),
+            str(new_value),
+            self.aws_provider,
+            description=f"The most recently auto-assigned VNI for cluster {self.cluster_name}",
+            overwrite=True
+        )
+        return new_value
+
+    def _get_current_autogen_vni(self) -> int:
+        ssm_param_name = constants.get_vni_current_ssm_param_name(self.cluster_name)
+        try:
+            raw_value = ssm_ops.get_ssm_param_value(ssm_param_name, self.aws_provider)
+            return int(raw_value)
+        except ssm_ops.ParamDoesNotExist:
+            # Subtract 1 because we increment before assigning a VNI and want the first value to be VNI_MIN
+            return self._update_current_autogen_vni(constants.VNI_MIN - 1)
+
+    def _update_recycled_vnis(self, new_values: List[int]) -> List[int]:
+        ssm_ops.put_ssm_param(
+            constants.get_vnis_recycled_ssm_param_name(self.cluster_name),
+            json.dumps(new_values),
+            self.aws_provider,
+            description=f"List of recycled VNIs ready for re-use by cluster {self.cluster_name}",
+            overwrite=True
+        )
+        return new_values
+
+    def _get_recycled_vnis(self) -> List[int]:
+        ssm_param_name = constants.get_vnis_recycled_ssm_param_name(self.cluster_name)
+        try:
+            raw_value = ssm_ops.get_ssm_param_value(ssm_param_name, self.aws_provider)
+            return json.loads(raw_value)
+        except ssm_ops.ParamDoesNotExist:
+            return self._update_recycled_vnis([])
+
+    def _update_user_vnis(self, new_value: List[int]) -> List[int]:
+        ssm_ops.put_ssm_param(
+            constants.get_vnis_user_ssm_param_name(self.cluster_name),
+            json.dumps(new_value),
+            self.aws_provider,
+            description=f"User-specified list of VNIs currently mapped to VPCs monitored by cluster {self.cluster_name}",
+            overwrite=True
+        )
+        return new_value
+
+    def _get_user_vnis(self) -> List[int]:
+        ssm_param_name = constants.get_vnis_user_ssm_param_name(self.cluster_name)
+        try:
+            raw_value = ssm_ops.get_ssm_param_value(ssm_param_name, self.aws_provider)
+            return json.loads(raw_value)
+        except ssm_ops.ParamDoesNotExist:
+            return self._update_user_vnis([])

--- a/test_manage_arkime/test_add_vpc.py
+++ b/test_manage_arkime/test_add_vpc.py
@@ -6,6 +6,7 @@ from manage_arkime.commands.add_vpc import cmd_add_vpc, _mirror_enis_in_subnet
 import manage_arkime.aws_interactions.ec2_interactions as ec2i
 from manage_arkime.aws_interactions.ssm_operations import ParamDoesNotExist
 import manage_arkime.constants as constants
+import manage_arkime.vni_provider as vnis
 
 
 @mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
@@ -118,12 +119,104 @@ def test_WHEN_mirror_enis_in_subnet_called_AND_already_mirrored_THEN_skips(mock_
 
 
 @mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
 @mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
 @mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
 @mock.patch("manage_arkime.commands.add_vpc.ec2i")
 @mock.patch("manage_arkime.commands.add_vpc.CdkClient")
-def test_WHEN_cmd_add_vpc_called_THEN_sets_up_mirroring(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror):
+def test_WHEN_cmd_add_vpc_called_AND_no_user_vni_THEN_sets_up_mirroring(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror, mock_vni_provider_cls):
     # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.get_next_vni.return_value = 42
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
+    subnet_ids = ["subnet-1", "subnet-2"]
+    mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
+
+    mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
+    mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "filter-1"]
+
+    mock_cdk = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_cdk
+
+    # Run our test
+    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", None)
+
+    # Check our results
+    expected_cdk_calls = [
+        mock.call(
+            [
+                constants.get_vpc_mirror_setup_stack_name("cluster-1", "vpc-1")
+            ],
+            aws_profile="profile",
+            aws_region="region",
+            context={
+                constants.CDK_CONTEXT_CMD_VAR: constants.CMD_ADD_VPC,
+                constants.CDK_CONTEXT_PARAMS_VAR: shlex.quote(json.dumps({
+                    "nameVpcMirrorStack": constants.get_vpc_mirror_setup_stack_name("cluster-1", "vpc-1"),
+                    "nameVpcSsmParam": constants.get_vpc_ssm_param_name("cluster-1", "vpc-1"),
+                    "idVni": str(42),
+                    "idVpc": "vpc-1",
+                    "idVpceService": "service-1",
+                    "listSubnetIds": subnet_ids,
+                    "listSubnetSsmParams": [constants.get_subnet_ssm_param_name("cluster-1", "vpc-1", subnet_id) for subnet_id in subnet_ids]
+                }))
+            }
+        )
+    ]
+
+    print(expected_cdk_calls)
+    print(mock_cdk.deploy.call_args_list)
+
+    assert expected_cdk_calls == mock_cdk.deploy.call_args_list
+
+    expected_mirror_calls = [
+        mock.call("cluster-1", "vpc-1", "subnet-1", "filter-1", 42, mock.ANY),
+        mock.call("cluster-1", "vpc-1", "subnet-2", "filter-1", 42, mock.ANY)
+    ]
+    assert expected_mirror_calls == mock_mirror.call_args_list
+
+    expected_vni_calls = [mock.call(42)]
+    assert expected_vni_calls == mock_vni_provider.use_next_vni.call_args_list
+
+@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
+@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
+@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
+def test_WHEN_cmd_add_vpc_called_AND_no_available_vnis_THEN_aborts(mock_cdk_client_cls, mock_mirror, mock_vni_provider_cls):
+    # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.get_next_vni.side_effect = vnis.VniPoolExhausted()
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
+    mock_cdk = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_cdk
+
+    # Run our test
+    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", None)
+
+    # Check our results
+    expected_cdk_calls = []
+    assert expected_cdk_calls == mock_cdk.deploy.call_args_list
+
+    expected_mirror_calls = []
+    assert expected_mirror_calls == mock_mirror.call_args_list
+
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.use_next_vni.call_args_list
+
+@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
+@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
+@mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
+@mock.patch("manage_arkime.commands.add_vpc.ec2i")
+@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
+def test_WHEN_cmd_add_vpc_called_AND_is_available_user_vni_THEN_sets_up_mirroring(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror, mock_vni_provider_cls):
+    # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.is_vni_available.return_value = True
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
     subnet_ids = ["subnet-1", "subnet-2"]
     mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
 
@@ -158,6 +251,7 @@ def test_WHEN_cmd_add_vpc_called_THEN_sets_up_mirroring(mock_cdk_client_cls, moc
             }
         )
     ]
+
     assert expected_cdk_calls == mock_cdk.deploy.call_args_list
 
     expected_mirror_calls = [
@@ -166,24 +260,24 @@ def test_WHEN_cmd_add_vpc_called_THEN_sets_up_mirroring(mock_cdk_client_cls, moc
     ]
     assert expected_mirror_calls == mock_mirror.call_args_list
 
-@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
-@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
-@mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
-@mock.patch("manage_arkime.commands.add_vpc.ec2i")
-@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
-def test_WHEN_cmd_add_vpc_called_AND_vni_too_small_THEN_aborts(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror):
-    # Set up our mock
-    subnet_ids = ["subnet-1", "subnet-2"]
-    mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
+    expected_vni_calls = [mock.call(1234)]
+    assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
 
-    mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
-    mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "filter-1"]
+@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
+@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
+@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
+def test_WHEN_cmd_add_vpc_called_AND_is_unavailable_user_vni_THEN_aborts(mock_cdk_client_cls, mock_mirror, mock_vni_provider_cls):
+    # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.is_vni_available.return_value = False
+    mock_vni_provider_cls.return_value = mock_vni_provider
 
     mock_cdk = mock.Mock()
     mock_cdk_client_cls.return_value = mock_cdk
 
     # Run our test
-    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", constants.VNI_MIN - 1)
+    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", 1234)
 
     # Check our results
     expected_cdk_calls = []
@@ -192,24 +286,24 @@ def test_WHEN_cmd_add_vpc_called_AND_vni_too_small_THEN_aborts(mock_cdk_client_c
     expected_mirror_calls = []
     assert expected_mirror_calls == mock_mirror.call_args_list
 
-@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
-@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
-@mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
-@mock.patch("manage_arkime.commands.add_vpc.ec2i")
-@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
-def test_WHEN_cmd_add_vpc_called_AND_vni_too_large_THEN_aborts(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror):
-    # Set up our mock
-    subnet_ids = ["subnet-1", "subnet-2"]
-    mock_ec2i.get_subnets_of_vpc.return_value = ["subnet-1", "subnet-2"]
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
 
-    mock_ssm.get_ssm_param_value.return_value = "" # Doesn't matter what this is besides an exception
-    mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", "filter-1"]
+@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
+@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
+@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
+def test_WHEN_cmd_add_vpc_called_AND_is_outrange_user_vni_THEN_aborts(mock_cdk_client_cls, mock_mirror, mock_vni_provider_cls):
+    # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.is_vni_available.side_effect = vnis.VniOutsideRange(1234)
+    mock_vni_provider_cls.return_value = mock_vni_provider
 
     mock_cdk = mock.Mock()
     mock_cdk_client_cls.return_value = mock_cdk
 
     # Run our test
-    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", constants.VNI_MAX + 1)
+    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", 1234)
 
     # Check our results
     expected_cdk_calls = []
@@ -218,12 +312,46 @@ def test_WHEN_cmd_add_vpc_called_AND_vni_too_large_THEN_aborts(mock_cdk_client_c
     expected_mirror_calls = []
     assert expected_mirror_calls == mock_mirror.call_args_list
 
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
+
 @mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
+@mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
+@mock.patch("manage_arkime.commands.add_vpc.CdkClient")
+def test_WHEN_cmd_add_vpc_called_AND_is_used_user_vni_THEN_aborts(mock_cdk_client_cls, mock_mirror, mock_vni_provider_cls):
+    # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.is_vni_available.side_effect = vnis.VniAlreadyUsed(1234)
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
+    mock_cdk = mock.Mock()
+    mock_cdk_client_cls.return_value = mock_cdk
+
+    # Run our test
+    cmd_add_vpc("profile", "region", "cluster-1", "vpc-1", 1234)
+
+    # Check our results
+    expected_cdk_calls = []
+    assert expected_cdk_calls == mock_cdk.deploy.call_args_list
+
+    expected_mirror_calls = []
+    assert expected_mirror_calls == mock_mirror.call_args_list
+
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
+
+@mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
 @mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
 @mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
 @mock.patch("manage_arkime.commands.add_vpc.CdkClient")
-def test_WHEN_cmd_add_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_client_cls, mock_ssm, mock_mirror):
+def test_WHEN_cmd_add_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_client_cls, mock_ssm, mock_mirror, mock_vni_provider_cls):
     # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.is_vni_available.return_value = True
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
     mock_ssm.ParamDoesNotExist = ParamDoesNotExist
     mock_ssm.get_ssm_param_value.side_effect = ParamDoesNotExist("")
 
@@ -240,13 +368,22 @@ def test_WHEN_cmd_add_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_c
     expected_mirror_calls = []
     assert expected_mirror_calls == mock_mirror.call_args_list
 
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
+    assert expected_vni_calls == mock_vni_provider.use_next_vni.call_args_list
+
 @mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.add_vpc.SsmVniProvider")
 @mock.patch("manage_arkime.commands.add_vpc._mirror_enis_in_subnet")
 @mock.patch("manage_arkime.commands.add_vpc.ssm_ops")
 @mock.patch("manage_arkime.commands.add_vpc.ec2i")
 @mock.patch("manage_arkime.commands.add_vpc.CdkClient")
-def test_WHEN_cmd_add_vpc_called_AND_vpc_doesnt_exist_THEN_skips(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror):
+def test_WHEN_cmd_add_vpc_called_AND_vpc_doesnt_exist_THEN_skips(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_mirror, mock_vni_provider_cls):
     # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider.is_vni_available.return_value = True
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
     mock_ec2i.VpcDoesNotExist = ec2i.VpcDoesNotExist
     mock_ec2i.get_subnets_of_vpc.side_effect = ec2i.VpcDoesNotExist("vpc-1")
 
@@ -264,3 +401,7 @@ def test_WHEN_cmd_add_vpc_called_AND_vpc_doesnt_exist_THEN_skips(mock_cdk_client
 
     expected_mirror_calls = []
     assert expected_mirror_calls == mock_mirror.call_args_list
+
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
+    assert expected_vni_calls == mock_vni_provider.use_next_vni.call_args_list

--- a/test_manage_arkime/test_add_vpc.py
+++ b/test_manage_arkime/test_add_vpc.py
@@ -260,7 +260,7 @@ def test_WHEN_cmd_add_vpc_called_AND_is_available_user_vni_THEN_sets_up_mirrorin
     ]
     assert expected_mirror_calls == mock_mirror.call_args_list
 
-    expected_vni_calls = [mock.call(1234)]
+    expected_vni_calls = [mock.call(1234, "vpc-1")]
     assert expected_vni_calls == mock_vni_provider.register_user_vni.call_args_list
 
 @mock.patch("manage_arkime.commands.add_vpc.AwsClientProvider", mock.Mock())

--- a/test_manage_arkime/test_remove_vpc.py
+++ b/test_manage_arkime/test_remove_vpc.py
@@ -62,13 +62,17 @@ def test_WHEN_remove_mirroring_for_eni_called_AND_session_doesnt_exist_THEN_hand
     assert expected_delete_ssm_calls == mock_ssm_ops.delete_ssm_param.call_args_list
 
 @mock.patch("manage_arkime.commands.remove_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.remove_vpc.SsmVniProvider")
 @mock.patch("manage_arkime.commands.remove_vpc._remove_mirroring_for_eni")
 @mock.patch("manage_arkime.commands.remove_vpc.ssm_ops")
 @mock.patch("manage_arkime.commands.remove_vpc.ec2i")
 @mock.patch("manage_arkime.commands.remove_vpc.CdkClient")
-def test_WHEN_cmd_remove_vpc_called_THEN_sets_up_mirroring(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_remove):
+def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_remove, mock_vni_provider_cls):
     # Set up our mock
-    mock_ssm.get_ssm_param_json_value.return_value = "service-1"
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
+    mock_ssm.get_ssm_param_json_value.side_effect = ["service-1", 1337]
     mock_ssm.get_ssm_params_by_path.return_value = [
         {"Name": "param-1", "Value": json.dumps({"subnetId": "subnet-1"})},
         {"Name": "param-2", "Value": json.dumps({"subnetId": "subnet-2"})},
@@ -111,13 +115,22 @@ def test_WHEN_cmd_remove_vpc_called_THEN_sets_up_mirroring(mock_cdk_client_cls, 
     ]
     assert expected_remove_calls == mock_remove.call_args_list
 
+    expected_vni_calls = [
+        mock.call(1337),
+    ]
+    assert expected_vni_calls == mock_vni_provider.relinquish_vni.call_args_list
+
 @mock.patch("manage_arkime.commands.remove_vpc.AwsClientProvider", mock.Mock())
+@mock.patch("manage_arkime.commands.remove_vpc.SsmVniProvider")
 @mock.patch("manage_arkime.commands.remove_vpc._remove_mirroring_for_eni")
 @mock.patch("manage_arkime.commands.remove_vpc.ssm_ops")
 @mock.patch("manage_arkime.commands.remove_vpc.ec2i")
 @mock.patch("manage_arkime.commands.remove_vpc.CdkClient")
-def test_WHEN_cmd_remove_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_remove):
+def test_WHEN_cmd_remove_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cdk_client_cls, mock_ec2i, mock_ssm, mock_remove, mock_vni_provider_cls):
     # Set up our mock
+    mock_vni_provider = mock.Mock()
+    mock_vni_provider_cls.return_value = mock_vni_provider
+
     mock_ssm.ParamDoesNotExist = ParamDoesNotExist
     mock_ssm.get_ssm_param_json_value.side_effect = ParamDoesNotExist("param-1")
 
@@ -133,3 +146,6 @@ def test_WHEN_cmd_remove_vpc_called_AND_cluster_doesnt_exist_THEN_aborts(mock_cd
 
     expected_remove_calls = []
     assert expected_remove_calls == mock_remove.call_args_list
+
+    expected_vni_calls = []
+    assert expected_vni_calls == mock_vni_provider.relinquish_vni.call_args_list

--- a/test_manage_arkime/test_remove_vpc.py
+++ b/test_manage_arkime/test_remove_vpc.py
@@ -115,9 +115,7 @@ def test_WHEN_cmd_remove_vpc_called_THEN_removes_mirroring(mock_cdk_client_cls, 
     ]
     assert expected_remove_calls == mock_remove.call_args_list
 
-    expected_vni_calls = [
-        mock.call(1337),
-    ]
+    expected_vni_calls = [mock.call(1337, "vpc-1")]
     assert expected_vni_calls == mock_vni_provider.relinquish_vni.call_args_list
 
 @mock.patch("manage_arkime.commands.remove_vpc.AwsClientProvider", mock.Mock())

--- a/test_manage_arkime/test_ssm_operations.py
+++ b/test_manage_arkime/test_ssm_operations.py
@@ -141,7 +141,7 @@ def test_WHEN_put_ssm_param_called_THEN_puts_it():
     mock_aws_provider.get_ssm.return_value = mock_ssm_client    
 
     # Run our test
-    ssm.put_ssm_param("my-param", "param-value", mock_aws_provider, description="param-desc", pattern=".*")
+    ssm.put_ssm_param("my-param", "param-value", mock_aws_provider, description="param-desc", pattern=".*", overwrite=True)
 
     # Check our results
     expected_put_calls = [
@@ -151,7 +151,8 @@ def test_WHEN_put_ssm_param_called_THEN_puts_it():
             Value="param-value",
             Type="String",
             AllowedPattern=".*",
-            Tier='Standard'
+            Tier='Standard',
+            Overwrite=True
         )
     ]
     assert expected_put_calls == mock_ssm_client.put_parameter.call_args_list

--- a/test_manage_arkime/test_ssm_vni_provider.py
+++ b/test_manage_arkime/test_ssm_vni_provider.py
@@ -7,38 +7,11 @@ import manage_arkime.constants as constants
 import manage_arkime.vni_provider as vni
 
 
-def test_WHEN_get_next_vni_called_AND_recycled_THEN_uses_recycled():
-    # Set up our mock
-    mock_aws = mock.Mock()
-
-    provider = vni.SsmVniProvider("cluster-1", mock_aws)
-
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [32, 17]
-    provider._get_recycled_vnis = mock_get_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_get_current_vni = mock.Mock()
-    provider._get_current_autogen_vni = mock_get_current_vni
-
-    # Run our test
-    actual_value = provider.get_next_vni()
-
-    # Check our results
-    expected_value = 17
-    assert expected_value == actual_value
-
 def test_WHEN_get_next_vni_called_AND_next_available_THEN_returns_it():
     # Set up our mock
     mock_aws = mock.Mock()
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
-
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = []
-    provider._get_recycled_vnis = mock_get_recycled
 
     mock_get_user_vnis = mock.Mock()
     mock_get_user_vnis.return_value = [5, 36]
@@ -61,10 +34,6 @@ def test_WHEN_get_next_vni_called_AND_next_not_available_THEN_handles_gracefully
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = []
-    provider._get_recycled_vnis = mock_get_recycled
-
     mock_get_user_vnis = mock.Mock()
     mock_get_user_vnis.return_value = [5, 36]
     provider._get_user_vnis = mock_get_user_vnis
@@ -86,10 +55,6 @@ def test_WHEN_get_next_vni_called_AND_pool_exhausted_THEN_raises():
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = []
-    provider._get_recycled_vnis = mock_get_recycled
-
     mock_get_user_vnis = mock.Mock()
     mock_get_user_vnis.return_value = [5, 36]
     provider._get_user_vnis = mock_get_user_vnis
@@ -102,47 +67,11 @@ def test_WHEN_get_next_vni_called_AND_pool_exhausted_THEN_raises():
     with pytest.raises(vni.VniPoolExhausted):
         provider.get_next_vni()
 
-def test_WHEN_use_next_vni_called_AND_recycled_THEN_updates():
-    # Set up our mock
-    mock_aws = mock.Mock()
-
-    provider = vni.SsmVniProvider("cluster-1", mock_aws)
-
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [32, 17]
-    provider._get_recycled_vnis = mock_get_recycled
-
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 64
-    provider._get_current_autogen_vni = mock_get_current_vni
-
-    mock_update_current_vni = mock.Mock()
-    provider._update_current_autogen_vni = mock_update_current_vni
-
-    # Run our test
-    provider.use_next_vni(17)
-
-    # Check our results
-    expected_update_recycled_calls = [mock.call([32])]
-    assert expected_update_recycled_calls == mock_update_recycled.call_args_list
-
-    assert not mock_update_current_vni.called
-
 def test_WHEN_use_next_vni_called_AND_autogen_THEN_updates():
     # Set up our mock
     mock_aws = mock.Mock()
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
-
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [32, 17]
-    provider._get_recycled_vnis = mock_get_recycled
-
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
 
     mock_get_current_vni = mock.Mock()
     mock_get_current_vni.return_value = 64
@@ -155,8 +84,6 @@ def test_WHEN_use_next_vni_called_AND_autogen_THEN_updates():
     provider.use_next_vni(65)
 
     # Check our results
-    assert not mock_update_recycled.called
-
     expected_update_current_calls = [mock.call(65)]
     assert expected_update_current_calls == mock_update_current_vni.call_args_list
 
@@ -166,12 +93,6 @@ def test_WHEN_use_next_vni_called_AND_outside_range_THEN_raises():
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_update_current_vni = mock.Mock()
-    provider._update_current_autogen_vni = mock_update_current_vni
-
     # Run our test
     with pytest.raises(vni.VniOutsideRange):
         provider.use_next_vni(constants.VNI_MIN - 1)
@@ -179,140 +100,45 @@ def test_WHEN_use_next_vni_called_AND_outside_range_THEN_raises():
     with pytest.raises(vni.VniOutsideRange):
         provider.use_next_vni(constants.VNI_MAX + 1)
 
-    # Check our results
-    assert not mock_update_recycled.called
-    assert not mock_update_current_vni.called
-
-def test_WHEN_register_user_vni_called_AND_available_THEN_registered():
+def test_WHEN_register_user_vni_called_AND_existing_THEN_registered():
     # Set up our mock
     mock_aws = mock.Mock()
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
+    mock_get_user_vnis_map = mock.Mock()
+    mock_get_user_vnis_map.return_value = {24: ["vpc-1", "vpc-2"], 36: ["vpc-3"]}
+    provider._get_user_vnis_mapping = mock_get_user_vnis_map
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [24, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
+    mock_update_user_vni_map = mock.Mock()
+    provider._update_user_vnis_mapping = mock_update_user_vni_map
 
     # Run our test
-    provider.register_user_vni(18)
+    provider.register_user_vni(24, "vpc-4")
 
     # Check our results
-    expected_update_user_calls = [mock.call([24, 36, 18])]
-    assert expected_update_user_calls == mock_update_user_vni.call_args_list
+    expected_update_user_calls = [mock.call({24: ["vpc-1", "vpc-2", "vpc-4"], 36: ["vpc-3"]})]
+    assert expected_update_user_calls == mock_update_user_vni_map.call_args_list
 
-    assert not mock_update_recycled.called
-
-def test_WHEN_register_user_vni_called_AND_recycled_THEN_registered():
+def test_WHEN_register_user_vni_called_AND_no_existing_THEN_registered():
     # Set up our mock
     mock_aws = mock.Mock()
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
+    mock_get_user_vnis_map = mock.Mock()
+    mock_get_user_vnis_map.return_value = {24: ["vpc-1", "vpc-2"], 36: ["vpc-3"]}
+    provider._get_user_vnis_mapping = mock_get_user_vnis_map
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [24, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
+    mock_update_user_vni_map = mock.Mock()
+    provider._update_user_vnis_mapping = mock_update_user_vni_map
 
     # Run our test
-    provider.register_user_vni(12)
+    provider.register_user_vni(18, "vpc-4")
 
     # Check our results
-    expected_update_user_calls = [mock.call([24, 36, 12])]
-    assert expected_update_user_calls == mock_update_user_vni.call_args_list
-
-    expected_update_recycled_calls = [mock.call([5])]
-    assert expected_update_recycled_calls == mock_update_recycled.call_args_list
-
-def test_WHEN_register_user_vni_called_AND_prev_autogen_THEN_raises():
-    # Set up our mock
-    mock_aws = mock.Mock()
-
-    provider = vni.SsmVniProvider("cluster-1", mock_aws)
-
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
-
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [24, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
-
-    # Run our test
-    with pytest.raises(vni.VniAlreadyUsed):
-        provider.register_user_vni(14)
-
-    # Check our results
-    assert not mock_update_user_vni.called
-    assert not mock_update_recycled.called
-
-def test_WHEN_register_user_vni_called_AND_already_registered_THEN_raises():
-    # Set up our mock
-    mock_aws = mock.Mock()
-
-    provider = vni.SsmVniProvider("cluster-1", mock_aws)
-
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
-
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [24, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
-
-    # Run our test
-    with pytest.raises(vni.VniAlreadyUsed):
-        provider.register_user_vni(24)
-
-    # Check our results
-    assert not mock_update_user_vni.called
-    assert not mock_update_recycled.called
+    expected_update_user_calls = [mock.call({18: ["vpc-4"], 24: ["vpc-1", "vpc-2"], 36: ["vpc-3"]})]
+    assert expected_update_user_calls == mock_update_user_vni_map.call_args_list
 
 def test_WHEN_register_user_vni_called_AND_outside_range_THEN_raises():
     # Set up our mock
@@ -320,22 +146,18 @@ def test_WHEN_register_user_vni_called_AND_outside_range_THEN_raises():
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
+    mock_update_user_vni_map = mock.Mock()
+    provider._update_user_vnis_mapping = mock_update_user_vni_map
 
     # Run our test
     with pytest.raises(vni.VniOutsideRange):
-        provider.register_user_vni(constants.VNI_MIN - 1)
+        provider.register_user_vni(constants.VNI_MIN - 1, "vpc-1")
 
     with pytest.raises(vni.VniOutsideRange):
-        provider.register_user_vni(constants.VNI_MAX + 1)
+        provider.register_user_vni(constants.VNI_MAX + 1, "vpc-1")
 
     # Check our results
-    assert not mock_update_user_vni.called
-    assert not mock_update_recycled.called
+    assert not mock_update_user_vni_map.called
 
 def test_WHEN_is_vni_available_called_THEN_as_expected():
     # Set up our mock
@@ -343,32 +165,16 @@ def test_WHEN_is_vni_available_called_THEN_as_expected():
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [24, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
-
-    # TEST: User-Specified
-    actual_value = provider.is_vni_available(24)
-    assert False == actual_value
-
-    # TEST: Autogen
-    actual_value = provider.is_vni_available(15)
-    assert False == actual_value
-
-    # TEST: Recycled
-    actual_value = provider.is_vni_available(12)
+    # TEST: Min Boundary Inclusive
+    actual_value = provider.is_vni_available(constants.VNI_MIN)
     assert True == actual_value
 
-    # TEST: Available
-    actual_value = provider.is_vni_available(19)
+    # TEST: Max Boundary Inclusive
+    actual_value = provider.is_vni_available(constants.VNI_MAX)
+    assert True == actual_value
+
+    # TEST: Between Min and Max
+    actual_value = provider.is_vni_available(constants.VNI_MIN + 1)
     assert True == actual_value
 
 def test_WHEN_is_vni_available_called_AND_out_of_range_THEN_raises():
@@ -384,72 +190,45 @@ def test_WHEN_is_vni_available_called_AND_out_of_range_THEN_raises():
     with pytest.raises(vni.VniOutsideRange):
         provider.is_vni_available(constants.VNI_MAX + 1)
 
-def test_WHEN_relinquish_vni_called_THEN_updates_state():
+def test_WHEN_relinquish_vni_called_AND_last_vpc_THEN_updates_state():
     # Set up our mock
     mock_aws = mock.Mock()
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
+    mock_get_user_vnis_map = mock.Mock()
+    mock_get_user_vnis_map.return_value = {24: ["vpc-1", "vpc-2"], 36: ["vpc-3"]}
+    provider._get_user_vnis_mapping = mock_get_user_vnis_map
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [24, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
+    mock_update_user_vni_map = mock.Mock()
+    provider._update_user_vnis_mapping = mock_update_user_vni_map
 
     # Run our test
-    provider.relinquish_vni(24)
+    provider.relinquish_vni(36, "vpc-3")
 
     # Check our results
-    expected_update_user_calls = [mock.call([36])]
-    assert expected_update_user_calls == mock_update_user_vni.call_args_list
+    expected_update_user_calls = [mock.call({24: ["vpc-1", "vpc-2"]})]
+    assert expected_update_user_calls == mock_update_user_vni_map.call_args_list
 
-    assert not mock_update_recycled.called
-
-def test_WHEN_relinquish_vni_called_AND_should_recycle_THEN_updates_state():
+def test_WHEN_relinquish_vni_called_AND_not_last_vpc_THEN_updates_state():
     # Set up our mock
     mock_aws = mock.Mock()
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_get_recycled = mock.Mock()
-    mock_get_recycled.return_value = [5, 12]
-    provider._get_recycled_vnis = mock_get_recycled
+    mock_get_user_vnis_map = mock.Mock()
+    mock_get_user_vnis_map.return_value = {24: ["vpc-1", "vpc-2"], 36: ["vpc-3"]}
+    provider._get_user_vnis_mapping = mock_get_user_vnis_map
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_get_user_vnis = mock.Mock()
-    mock_get_user_vnis.return_value = [8, 36]
-    provider._get_user_vnis = mock_get_user_vnis
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
-
-    mock_get_current_vni = mock.Mock()
-    mock_get_current_vni.return_value = 16
-    provider._get_current_autogen_vni = mock_get_current_vni
+    mock_update_user_vni_map = mock.Mock()
+    provider._update_user_vnis_mapping = mock_update_user_vni_map
 
     # Run our test
-    provider.relinquish_vni(8)
+    provider.relinquish_vni(24, "vpc-1")
 
     # Check our results
-    expected_update_user_calls = [mock.call([36])]
-    assert expected_update_user_calls == mock_update_user_vni.call_args_list
-
-    expected_update_recycled_calls = [mock.call([5, 12, 8])]
-    assert expected_update_recycled_calls == mock_update_recycled.call_args_list
+    expected_update_user_calls = [mock.call({24: ["vpc-2"], 36: ["vpc-3"]})]
+    assert expected_update_user_calls == mock_update_user_vni_map.call_args_list
 
 def test_WHEN_relinquish_vni_called_AND_out_of_range_THEN_raises():
     # Set up our mock
@@ -457,22 +236,18 @@ def test_WHEN_relinquish_vni_called_AND_out_of_range_THEN_raises():
 
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
 
-    mock_update_recycled = mock.Mock()
-    provider._update_recycled_vnis = mock_update_recycled
-
-    mock_update_user_vni = mock.Mock()
-    provider._update_user_vnis = mock_update_user_vni
+    mock_update_user_vni_map = mock.Mock()
+    provider._update_user_vnis_mapping = mock_update_user_vni_map
 
     # Run our test
     with pytest.raises(vni.VniOutsideRange):
-        provider.relinquish_vni(constants.VNI_MIN - 1)
+        provider.relinquish_vni(constants.VNI_MIN - 1, "vpc-1")
 
     with pytest.raises(vni.VniOutsideRange):
-        provider.relinquish_vni(constants.VNI_MAX + 1)
+        provider.relinquish_vni(constants.VNI_MAX + 1, "vpc-1")
 
     # Check our results
-    assert not mock_update_user_vni.called
-    assert not mock_update_recycled.called
+    assert not mock_update_user_vni_map.called
 
 @mock.patch('manage_arkime.vni_provider.ssm_ops')
 def test_WHEN_update_current_autogen_vni_called_THEN_updates_it(mock_ssm):
@@ -609,22 +384,22 @@ def test_WHEN_get_recycled_vnis_called_AND_not_initialized_THEN_handles_graceful
     assert expected_initialize_calls == mock_initialize.call_args_list
 
 @mock.patch('manage_arkime.vni_provider.ssm_ops')
-def test_WHEN_update_user_vnis_called_THEN_initializes_it(mock_ssm):
+def test_WHEN_update_user_vnis_mapping_called_THEN_sets_it(mock_ssm):
     # Set up our mock
     mock_aws = mock.Mock()
 
     # Run our test
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
-    actual_value = provider._update_user_vnis([2, 19, 37])
+    actual_value = provider._update_user_vnis_mapping({1: ["vpc-1", "vpc-2"], 2: ["vpc-3"]})
 
     # Check our results
-    expected_value = [2, 19, 37]
+    expected_value = {1: ["vpc-1", "vpc-2"], 2: ["vpc-3"]}
     assert expected_value == actual_value
 
     expected_ssm_calls = [
         mock.call(
             constants.get_vnis_user_ssm_param_name("cluster-1"),
-            json.dumps([2, 19, 37]),
+            json.dumps({1: ["vpc-1", "vpc-2"], 2: ["vpc-3"]}),
             mock_aws,
             description=mock.ANY,
             overwrite=True
@@ -633,9 +408,52 @@ def test_WHEN_update_user_vnis_called_THEN_initializes_it(mock_ssm):
     assert expected_ssm_calls == mock_ssm.put_ssm_param.call_args_list
 
 @mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_user_vnis_mapping_called_THEN_returns_them(mock_ssm):
+    # Set up our mock
+    mock_ssm.get_ssm_param_value.return_value = json.dumps({42: ["vpc-1", "vpc-2"], 16: ["vpc-3"]})
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._get_user_vnis_mapping()
+
+    # Check our results
+    expected_value = {42: ["vpc-1", "vpc-2"], 16: ["vpc-3"]}
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(constants.get_vnis_user_ssm_param_name("cluster-1"), mock_aws)
+    ]
+    assert expected_ssm_calls == mock_ssm.get_ssm_param_value.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_user_vnis_mapping_called_AND_not_initialized_THEN_handles_gracefully(mock_ssm):
+    # Set up our mock
+    mock_ssm.ParamDoesNotExist = ParamDoesNotExist
+    mock_ssm.get_ssm_param_value.side_effect = ParamDoesNotExist("param-1")
+    mock_aws = mock.Mock()
+
+    mock_initialize = mock.Mock()
+    mock_initialize.return_value = {}
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    provider._update_user_vnis_mapping = mock_initialize
+
+    # Run our test    
+    actual_value = provider._get_user_vnis_mapping()
+
+    # Check our results
+    expected_value = {}
+    assert expected_value == actual_value
+
+    expected_initialize_calls = [
+        mock.call({})
+    ]
+    assert expected_initialize_calls == mock_initialize.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
 def test_WHEN_get_user_vnis_called_THEN_returns_them(mock_ssm):
     # Set up our mock
-    mock_ssm.get_ssm_param_value.return_value = json.dumps([42, 16, 1337])
+    mock_ssm.get_ssm_param_value.return_value = json.dumps({42: ["vpc-1", "vpc-2"], 16: ["vpc-3"]})
     mock_aws = mock.Mock()
 
     # Run our test
@@ -643,7 +461,7 @@ def test_WHEN_get_user_vnis_called_THEN_returns_them(mock_ssm):
     actual_value = provider._get_user_vnis()
 
     # Check our results
-    expected_value = [42, 16, 1337]
+    expected_value = [42, 16]
     assert expected_value == actual_value
 
     expected_ssm_calls = [
@@ -659,9 +477,9 @@ def test_WHEN_get_user_vnis_called_AND_not_initialized_THEN_handles_gracefully(m
     mock_aws = mock.Mock()
 
     mock_initialize = mock.Mock()
-    mock_initialize.return_value = []
+    mock_initialize.return_value = {}
     provider = vni.SsmVniProvider("cluster-1", mock_aws)
-    provider._update_user_vnis = mock_initialize
+    provider._update_user_vnis_mapping = mock_initialize
 
     # Run our test    
     actual_value = provider._get_user_vnis()
@@ -671,6 +489,6 @@ def test_WHEN_get_user_vnis_called_AND_not_initialized_THEN_handles_gracefully(m
     assert expected_value == actual_value
 
     expected_initialize_calls = [
-        mock.call([])
+        mock.call({})
     ]
     assert expected_initialize_calls == mock_initialize.call_args_list

--- a/test_manage_arkime/test_ssm_vni_provider.py
+++ b/test_manage_arkime/test_ssm_vni_provider.py
@@ -1,0 +1,676 @@
+import json
+import pytest
+import unittest.mock as mock
+
+from manage_arkime.aws_interactions.ssm_operations import ParamDoesNotExist
+import manage_arkime.constants as constants
+import manage_arkime.vni_provider as vni
+
+
+def test_WHEN_get_next_vni_called_AND_recycled_THEN_uses_recycled():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [32, 17]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_get_current_vni = mock.Mock()
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    actual_value = provider.get_next_vni()
+
+    # Check our results
+    expected_value = 17
+    assert expected_value == actual_value
+
+def test_WHEN_get_next_vni_called_AND_next_available_THEN_returns_it():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = []
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [5, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 6
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    actual_value = provider.get_next_vni()
+
+    # Check our results
+    expected_value = 7
+    assert expected_value == actual_value
+
+def test_WHEN_get_next_vni_called_AND_next_not_available_THEN_handles_gracefully():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = []
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [5, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 4
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    actual_value = provider.get_next_vni()
+
+    # Check our results
+    expected_value = 6
+    assert expected_value == actual_value
+
+def test_WHEN_get_next_vni_called_AND_pool_exhausted_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = []
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [5, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = constants.VNI_MAX
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    with pytest.raises(vni.VniPoolExhausted):
+        provider.get_next_vni()
+
+def test_WHEN_use_next_vni_called_AND_recycled_THEN_updates():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [32, 17]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 64
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    mock_update_current_vni = mock.Mock()
+    provider._update_current_autogen_vni = mock_update_current_vni
+
+    # Run our test
+    provider.use_next_vni(17)
+
+    # Check our results
+    expected_update_recycled_calls = [mock.call([32])]
+    assert expected_update_recycled_calls == mock_update_recycled.call_args_list
+
+    assert not mock_update_current_vni.called
+
+def test_WHEN_use_next_vni_called_AND_autogen_THEN_updates():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [32, 17]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 64
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    mock_update_current_vni = mock.Mock()
+    provider._update_current_autogen_vni = mock_update_current_vni
+
+    # Run our test
+    provider.use_next_vni(65)
+
+    # Check our results
+    assert not mock_update_recycled.called
+
+    expected_update_current_calls = [mock.call(65)]
+    assert expected_update_current_calls == mock_update_current_vni.call_args_list
+
+def test_WHEN_use_next_vni_called_AND_outside_range_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_update_current_vni = mock.Mock()
+    provider._update_current_autogen_vni = mock_update_current_vni
+
+    # Run our test
+    with pytest.raises(vni.VniOutsideRange):
+        provider.use_next_vni(constants.VNI_MIN - 1)
+
+    with pytest.raises(vni.VniOutsideRange):
+        provider.use_next_vni(constants.VNI_MAX + 1)
+
+    # Check our results
+    assert not mock_update_recycled.called
+    assert not mock_update_current_vni.called
+
+def test_WHEN_register_user_vni_called_AND_available_THEN_registered():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [24, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    provider.register_user_vni(18)
+
+    # Check our results
+    expected_update_user_calls = [mock.call([24, 36, 18])]
+    assert expected_update_user_calls == mock_update_user_vni.call_args_list
+
+    assert not mock_update_recycled.called
+
+def test_WHEN_register_user_vni_called_AND_recycled_THEN_registered():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [24, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    provider.register_user_vni(12)
+
+    # Check our results
+    expected_update_user_calls = [mock.call([24, 36, 12])]
+    assert expected_update_user_calls == mock_update_user_vni.call_args_list
+
+    expected_update_recycled_calls = [mock.call([5])]
+    assert expected_update_recycled_calls == mock_update_recycled.call_args_list
+
+def test_WHEN_register_user_vni_called_AND_prev_autogen_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [24, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    with pytest.raises(vni.VniAlreadyUsed):
+        provider.register_user_vni(14)
+
+    # Check our results
+    assert not mock_update_user_vni.called
+    assert not mock_update_recycled.called
+
+def test_WHEN_register_user_vni_called_AND_already_registered_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [24, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    with pytest.raises(vni.VniAlreadyUsed):
+        provider.register_user_vni(24)
+
+    # Check our results
+    assert not mock_update_user_vni.called
+    assert not mock_update_recycled.called
+
+def test_WHEN_register_user_vni_called_AND_outside_range_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    # Run our test
+    with pytest.raises(vni.VniOutsideRange):
+        provider.register_user_vni(constants.VNI_MIN - 1)
+
+    with pytest.raises(vni.VniOutsideRange):
+        provider.register_user_vni(constants.VNI_MAX + 1)
+
+    # Check our results
+    assert not mock_update_user_vni.called
+    assert not mock_update_recycled.called
+
+def test_WHEN_is_vni_available_called_THEN_as_expected():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [24, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # TEST: User-Specified
+    actual_value = provider.is_vni_available(24)
+    assert False == actual_value
+
+    # TEST: Autogen
+    actual_value = provider.is_vni_available(15)
+    assert False == actual_value
+
+    # TEST: Recycled
+    actual_value = provider.is_vni_available(12)
+    assert True == actual_value
+
+    # TEST: Available
+    actual_value = provider.is_vni_available(19)
+    assert True == actual_value
+
+def test_WHEN_is_vni_available_called_AND_out_of_range_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    # Run our test
+    with pytest.raises(vni.VniOutsideRange):
+        provider.is_vni_available(constants.VNI_MIN - 1)
+
+    with pytest.raises(vni.VniOutsideRange):
+        provider.is_vni_available(constants.VNI_MAX + 1)
+
+def test_WHEN_relinquish_vni_called_THEN_updates_state():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [24, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    provider.relinquish_vni(24)
+
+    # Check our results
+    expected_update_user_calls = [mock.call([36])]
+    assert expected_update_user_calls == mock_update_user_vni.call_args_list
+
+    assert not mock_update_recycled.called
+
+def test_WHEN_relinquish_vni_called_AND_should_recycle_THEN_updates_state():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_get_recycled = mock.Mock()
+    mock_get_recycled.return_value = [5, 12]
+    provider._get_recycled_vnis = mock_get_recycled
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_get_user_vnis = mock.Mock()
+    mock_get_user_vnis.return_value = [8, 36]
+    provider._get_user_vnis = mock_get_user_vnis
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    mock_get_current_vni = mock.Mock()
+    mock_get_current_vni.return_value = 16
+    provider._get_current_autogen_vni = mock_get_current_vni
+
+    # Run our test
+    provider.relinquish_vni(8)
+
+    # Check our results
+    expected_update_user_calls = [mock.call([36])]
+    assert expected_update_user_calls == mock_update_user_vni.call_args_list
+
+    expected_update_recycled_calls = [mock.call([5, 12, 8])]
+    assert expected_update_recycled_calls == mock_update_recycled.call_args_list
+
+def test_WHEN_relinquish_vni_called_AND_out_of_range_THEN_raises():
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+
+    mock_update_recycled = mock.Mock()
+    provider._update_recycled_vnis = mock_update_recycled
+
+    mock_update_user_vni = mock.Mock()
+    provider._update_user_vnis = mock_update_user_vni
+
+    # Run our test
+    with pytest.raises(vni.VniOutsideRange):
+        provider.relinquish_vni(constants.VNI_MIN - 1)
+
+    with pytest.raises(vni.VniOutsideRange):
+        provider.relinquish_vni(constants.VNI_MAX + 1)
+
+    # Check our results
+    assert not mock_update_user_vni.called
+    assert not mock_update_recycled.called
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_update_current_autogen_vni_called_THEN_updates_it(mock_ssm):
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._update_current_autogen_vni(2)
+
+    # Check our results
+    expected_value = 2
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(
+            constants.get_vni_current_ssm_param_name("cluster-1"),
+            str(2),
+            mock_aws,
+            description=mock.ANY,
+            overwrite=True
+        )
+    ]
+    assert expected_ssm_calls == mock_ssm.put_ssm_param.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_current_autogen_vni_called_THEN_returns_it(mock_ssm):
+    # Set up our mock
+    mock_ssm.get_ssm_param_value.return_value = "31"
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._get_current_autogen_vni()
+
+    # Check our results
+    expected_value = 31
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(constants.get_vni_current_ssm_param_name("cluster-1"), mock_aws)
+    ]
+    assert expected_ssm_calls == mock_ssm.get_ssm_param_value.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_current_autogen_vni_called_AND_not_initialized_THEN_handles_gracefully(mock_ssm):
+    # Set up our mock
+    mock_ssm.ParamDoesNotExist = ParamDoesNotExist
+    mock_ssm.get_ssm_param_value.side_effect = ParamDoesNotExist("param-1")
+    mock_aws = mock.Mock()
+
+    mock_initialize = mock.Mock()
+    mock_initialize.return_value = constants.VNI_MIN - 1
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    provider._update_current_autogen_vni = mock_initialize
+
+    # Run our test    
+    actual_value = provider._get_current_autogen_vni()
+
+    # Check our results
+    expected_value = constants.VNI_MIN - 1
+    assert expected_value == actual_value
+
+    expected_initialize_calls = [
+        mock.call(constants.VNI_MIN - 1)
+    ]
+    assert expected_initialize_calls == mock_initialize.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_update_recycled_vnis_called_THEN_updates_it(mock_ssm):
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._update_recycled_vnis([17, 31, 82])
+
+    # Check our results
+    expected_value = [17, 31, 82]
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(
+            constants.get_vnis_recycled_ssm_param_name("cluster-1"),
+            json.dumps([17, 31, 82]),
+            mock_aws,
+            description=mock.ANY,
+            overwrite=True
+        )
+    ]
+    assert expected_ssm_calls == mock_ssm.put_ssm_param.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_recycled_vnis_called_THEN_returns_them(mock_ssm):
+    # Set up our mock
+    mock_ssm.get_ssm_param_value.return_value = json.dumps([90210, 8675309])
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._get_recycled_vnis()
+
+    # Check our results
+    expected_value = [90210, 8675309]
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(constants.get_vnis_recycled_ssm_param_name("cluster-1"), mock_aws)
+    ]
+    assert expected_ssm_calls == mock_ssm.get_ssm_param_value.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_recycled_vnis_called_AND_not_initialized_THEN_handles_gracefully(mock_ssm):
+    # Set up our mock
+    mock_ssm.ParamDoesNotExist = ParamDoesNotExist
+    mock_ssm.get_ssm_param_value.side_effect = ParamDoesNotExist("param-1")
+    mock_aws = mock.Mock()
+
+    mock_initialize = mock.Mock()
+    mock_initialize.return_value = []
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    provider._update_recycled_vnis = mock_initialize
+
+    # Run our test    
+    actual_value = provider._get_recycled_vnis()
+
+    # Check our results
+    expected_value = []
+    assert expected_value == actual_value
+
+    expected_initialize_calls = [
+        mock.call([])
+    ]
+    assert expected_initialize_calls == mock_initialize.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_update_user_vnis_called_THEN_initializes_it(mock_ssm):
+    # Set up our mock
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._update_user_vnis([2, 19, 37])
+
+    # Check our results
+    expected_value = [2, 19, 37]
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(
+            constants.get_vnis_user_ssm_param_name("cluster-1"),
+            json.dumps([2, 19, 37]),
+            mock_aws,
+            description=mock.ANY,
+            overwrite=True
+        )
+    ]
+    assert expected_ssm_calls == mock_ssm.put_ssm_param.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_user_vnis_called_THEN_returns_them(mock_ssm):
+    # Set up our mock
+    mock_ssm.get_ssm_param_value.return_value = json.dumps([42, 16, 1337])
+    mock_aws = mock.Mock()
+
+    # Run our test
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    actual_value = provider._get_user_vnis()
+
+    # Check our results
+    expected_value = [42, 16, 1337]
+    assert expected_value == actual_value
+
+    expected_ssm_calls = [
+        mock.call(constants.get_vnis_user_ssm_param_name("cluster-1"), mock_aws)
+    ]
+    assert expected_ssm_calls == mock_ssm.get_ssm_param_value.call_args_list
+
+@mock.patch('manage_arkime.vni_provider.ssm_ops')
+def test_WHEN_get_user_vnis_called_AND_not_initialized_THEN_handles_gracefully(mock_ssm):
+    # Set up our mock
+    mock_ssm.ParamDoesNotExist = ParamDoesNotExist
+    mock_ssm.get_ssm_param_value.side_effect = ParamDoesNotExist("param-1")
+    mock_aws = mock.Mock()
+
+    mock_initialize = mock.Mock()
+    mock_initialize.return_value = []
+    provider = vni.SsmVniProvider("cluster-1", mock_aws)
+    provider._update_user_vnis = mock_initialize
+
+    # Run our test    
+    actual_value = provider._get_user_vnis()
+
+    # Check our results
+    expected_value = []
+    assert expected_value == actual_value
+
+    expected_initialize_calls = [
+        mock.call([])
+    ]
+    assert expected_initialize_calls == mock_initialize.call_args_list


### PR DESCRIPTION
## Description
* Revamped how VNI assignment works.  If the user supplies a specific VNI, and it's valid, then that is used.  If the user does not supply a specific VNI for their VPC, then we find the next smallest, available integer to use as the VNI.

## Tasks
* https://github.com/arkime/cloud-demo/issues/27

## Testing
* Added unit tests
* Ran the commands manually in my AWS account.  Among other manual tests, ran following test sequence on an empty cluster:
    * `add-vpc` with a user-specified VNI of `1`
    * `add-vpc` again without specifying a VNI; VNI `2` was correctly chosen
    * `remove-vpc` on the VPC with VNI `1`
    * `add-vpc` again without specifying a VNI; VNI `3` was correctly chosen

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py list-clusters
2023-04-24 15:00:02 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:00:02 - Using AWS Credential Profile: default
2023-04-24 15:00:02 - Using AWS Region: default from AWS Config settings
2023-04-24 15:00:02 - Retrieving cluster details...
2023-04-24 15:00:04 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster2",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": []
    }
]
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py add-vpc --cluster-name MyCluster --vpc-id vpc-003a3436126a5a140 --force-vni 1
2023-04-24 15:00:08 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:00:08 - Using AWS Credential Profile: default
2023-04-24 15:00:08 - Using AWS Region: default from AWS Config settings
2023-04-24 15:00:10 - Deploying shared mirroring components via CDK...
2023-04-24 15:00:10 - Executing command: deploy MyCluster-vpc-003a3436126a5a140-Mirror
2023-04-24 15:00:10 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-04-24 15:03:38 - Deployment succeeded
2023-04-24 15:03:40 - Creating mirroring session for ENI eni-0ab9fda80f721453f
2023-04-24 15:03:40 - Eni eni-0ab9fda80f721453f is of unsupported type gateway_load_balancer_endpoint; skipping
2023-04-24 15:03:40 - Creating mirroring session for ENI eni-020aa9a2f297424d2
2023-04-24 15:03:41 - Eni eni-020aa9a2f297424d2 is of unsupported type nat_gateway; skipping
2023-04-24 15:03:41 - Creating mirroring session for ENI eni-0bc0df75d5300f9bb
2023-04-24 15:03:43 - Creating mirroring session for ENI eni-0233d6bae9934660e
2023-04-24 15:03:44 - Eni eni-0233d6bae9934660e is of unsupported type gateway_load_balancer_endpoint; skipping
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py list-clusters
2023-04-24 15:06:02 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:06:02 - Using AWS Credential Profile: default
2023-04-24 15:06:02 - Using AWS Region: default from AWS Config settings
2023-04-24 15:06:02 - Retrieving cluster details...
2023-04-24 15:06:04 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-003a3436126a5a140",
                "vni": "1"
            }
        ]
    },
    {
        "cluster_name": "MyCluster2",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": []
    }
]
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py add-vpc --cluster-name MyCluster --vpc-id vpc-085d9c6085d49263e
2023-04-24 15:06:16 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:06:16 - Using AWS Credential Profile: default
2023-04-24 15:06:16 - Using AWS Region: default from AWS Config settings
2023-04-24 15:06:18 - Deploying shared mirroring components via CDK...
2023-04-24 15:06:18 - Executing command: deploy MyCluster-vpc-085d9c6085d49263e-Mirror
2023-04-24 15:06:18 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-04-24 15:09:46 - Deployment succeeded
2023-04-24 15:09:47 - Creating mirroring session for ENI eni-0255a87b7b20d9776
2023-04-24 15:09:48 - Eni eni-0255a87b7b20d9776 is of unsupported type gateway_load_balancer_endpoint; skipping
2023-04-24 15:09:48 - Creating mirroring session for ENI eni-063bf223f6eba509b
2023-04-24 15:09:51 - Creating mirroring session for ENI eni-006787294f0dc06db
2023-04-24 15:09:51 - Eni eni-006787294f0dc06db is of unsupported type gateway_load_balancer_endpoint; skipping
2023-04-24 15:09:52 - Creating mirroring session for ENI eni-0d5cd6940daa297e1
2023-04-24 15:09:52 - Eni eni-0d5cd6940daa297e1 is of unsupported type nat_gateway; skipping
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py list-clusters
2023-04-24 15:10:16 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:10:16 - Using AWS Credential Profile: default
2023-04-24 15:10:16 - Using AWS Region: default from AWS Config settings
2023-04-24 15:10:16 - Retrieving cluster details...
2023-04-24 15:10:18 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-003a3436126a5a140",
                "vni": "1"
            },
            {
                "vpc_id": "vpc-085d9c6085d49263e",
                "vni": "2"
            }
        ]
    },
    {
        "cluster_name": "MyCluster2",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": []
    }
]
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py remove-vpc --cluster-name MyCluster --vpc-id vpc-003a3436126a5a140
2023-04-24 15:10:30 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:10:30 - Using AWS Credential Profile: default
2023-04-24 15:10:30 - Using AWS Region: default from AWS Config settings
2023-04-24 15:10:32 - Removing mirroring session for eni eni-0bc0df75d5300f9bb; deleting mirroring session tms-07e1d710ddd3f16e2...
2023-04-24 15:10:33 - Deleting SSM parameter for ENI eni-0bc0df75d5300f9bb...
2023-04-24 15:10:34 - Tearing down shared mirroring components via CDK...
2023-04-24 15:10:35 - ================================================================================
2023-04-24 15:10:35 - USER ACTION REQUIRED:
2023-04-24 15:10:35 - --------------------------------------------------------------------------------
Your command will result in the the following CloudFormation stacks being destroyed in AWS Account 968674222892 and Region us-east-2: ['MyCluster-vpc-003a3436126a5a140-Mirror']

Do you wish to proceed (y/yes or n/no)? y
2023-04-24 15:10:37 - Executing command: destroy --force MyCluster-vpc-003a3436126a5a140-Mirror
2023-04-24 15:10:37 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-04-24 15:12:15 - Destruction succeeded
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py list-clusters
2023-04-24 15:13:09 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:13:09 - Using AWS Credential Profile: default
2023-04-24 15:13:09 - Using AWS Region: default from AWS Config settings
2023-04-24 15:13:09 - Retrieving cluster details...
2023-04-24 15:13:11 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-085d9c6085d49263e",
                "vni": "2"
            }
        ]
    },
    {
        "cluster_name": "MyCluster2",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": []
    }
]
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py add-vpc --cluster-name MyCluster --vpc-id vpc-003a3436126a5a140
2023-04-24 15:13:32 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:13:32 - Using AWS Credential Profile: default
2023-04-24 15:13:32 - Using AWS Region: default from AWS Config settings
2023-04-24 15:13:34 - Deploying shared mirroring components via CDK...
2023-04-24 15:13:34 - Executing command: deploy MyCluster-vpc-003a3436126a5a140-Mirror
2023-04-24 15:13:34 - NOTE: This operation can take a while.  You can 'tail -f' the logfile to track the status.
2023-04-24 15:17:02 - Deployment succeeded
2023-04-24 15:17:03 - Creating mirroring session for ENI eni-020aa9a2f297424d2
2023-04-24 15:17:04 - Eni eni-020aa9a2f297424d2 is of unsupported type nat_gateway; skipping
2023-04-24 15:17:04 - Creating mirroring session for ENI eni-05dc597664774be8d
2023-04-24 15:17:04 - Eni eni-05dc597664774be8d is of unsupported type gateway_load_balancer_endpoint; skipping
2023-04-24 15:17:05 - Creating mirroring session for ENI eni-0bc0df75d5300f9bb
2023-04-24 15:17:07 - Creating mirroring session for ENI eni-0c77fdd1b967fa8d5
2023-04-24 15:17:07 - Eni eni-0c77fdd1b967fa8d5 is of unsupported type gateway_load_balancer_endpoint; skipping
```

```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py list-clusters
2023-04-24 15:17:28 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-04-24 15:17:28 - Using AWS Credential Profile: default
2023-04-24 15:17:28 - Using AWS Region: default from AWS Config settings
2023-04-24 15:17:28 - Retrieving cluster details...
2023-04-24 15:17:30 - Deployed Clusters:
[
    {
        "cluster_name": "MyCluster",
        "monitored_vpcs": [
            {
                "vpc_id": "vpc-003a3436126a5a140",
                "vni": "3"
            },
            {
                "vpc_id": "vpc-085d9c6085d49263e",
                "vni": "2"
            }
        ]
    },
    {
        "cluster_name": "MyCluster2",
        "monitored_vpcs": []
    },
    {
        "cluster_name": "MyCluster3",
        "monitored_vpcs": []
    }
]
```