### PR TITLE
Mirroring auto-created/destroyed for EC2 instances

### DIFF
--- a/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
+++ b/cdk-lib/traffic-gen-sample/traffic-gen-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
+import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -7,51 +8,19 @@ import * as logs from 'aws-cdk-lib/aws-logs';
 import * as path from 'path'
 import { Construct } from 'constructs';
 
+
 export class TrafficGenStack extends cdk.Stack {
     constructor(scope: Construct, id: string, props?: cdk.StackProps) {
         super(scope, id, props);
 
-        // Stock VPC w/ a Public/Private subnet pair in 1 AZ along with NATGateways providing internet access to the
-        // private VPCs.
+        /**
+         * Set up our demo Traffic Generator's networking
+         */
+        // This is a Stock VPC w/ a Public/Private subnet pair in 1 AZ along with NATGateways providing internet access 
+        // to the private subnet.
         const vpc = new ec2.Vpc(this, 'VPC', {maxAzs: 1});
 
-        // Key to encrypt SSM traffic when using ECS Exec to shell into the container
-        const ksmEncryptionKey = new kms.Key(this, 'ECSClusterKey', {
-            enableKeyRotation: true,
-        });
-
-        // Create a Fargate service that runs a single instance of our traffic generation image
-        const cluster = new ecs.Cluster(this, 'Cluster', {
-            vpc,
-            executeCommandConfiguration: { kmsKey: ksmEncryptionKey }
-        });
-
-        const taskDefinition = new ecs.FargateTaskDefinition(this, 'TaskDef', {
-            memoryLimitMiB: 512,
-            cpu: 256,
-        });
-        taskDefinition.addToTaskRolePolicy(
-            new iam.PolicyStatement({
-                effect: iam.Effect.ALLOW,
-                actions: ['kms:Decrypt'], // Required for ECS Exec & shelling into the container
-                resources: [ksmEncryptionKey.keyArn]
-            }),
-        );
-
-        const container = taskDefinition.addContainer('FargateContainer', {
-            image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, '..', '..', 'docker-traffic-gen')),
-            memoryLimitMiB: 512,
-            logging: new ecs.AwsLogDriver({ streamPrefix: 'DemoTrafficGen', mode: ecs.AwsLogDriverMode.NON_BLOCKING })
-        });
-        
-        const service = new ecs.FargateService(this, 'Service', {
-            cluster,
-            taskDefinition,
-            desiredCount: 1,
-            enableExecuteCommand: true
-        });
-
-        // Set up VPC Flow Logs to enable visibility of the traffic mirroring on the user-side    
+        // Set up VPC Flow Logs to enable visibility of the traffic mirroring on the user-side
         const flowLogsGroup = new logs.LogGroup(this, 'FlowLogsLogGroup', {
             logGroupName: `FlowLogs-${id}`,
             removalPolicy: cdk.RemovalPolicy.DESTROY,
@@ -63,5 +32,99 @@ export class TrafficGenStack extends cdk.Stack {
             destination: ec2.FlowLogDestination.toCloudWatchLogs(flowLogsGroup),
         });
 
+        /**
+         * Set up some shared components.
+         */
+        // Key to encrypt SSM traffic when using ECS Exec to shell into the container
+        const ssmKey = new kms.Key(this, 'SsmKey', {
+            enableKeyRotation: true,
+        });
+
+        /**
+         * Create a Fargate service that runs our traffic generation image
+         */
+        const fargateCluster = new ecs.Cluster(this, 'FargateCluster', {
+            vpc,
+            executeCommandConfiguration: { kmsKey: ssmKey }
+        });
+
+        const fargateTaskDef = new ecs.FargateTaskDefinition(this, 'TaskDef', {
+            memoryLimitMiB: 512,
+            cpu: 256,
+        });
+        fargateTaskDef.addToTaskRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: ['kms:Decrypt'], // Required for ECS Exec & shelling into the container
+                resources: [ssmKey.keyArn]
+            }),
+        );
+
+        const fargateContainer = fargateTaskDef.addContainer('FargateContainer', {
+            image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, '..', '..', 'docker-traffic-gen')),
+            memoryLimitMiB: 512,
+            logging: new ecs.AwsLogDriver({ streamPrefix: 'DemoTrafficGenFargate', mode: ecs.AwsLogDriverMode.NON_BLOCKING })
+        });
+        
+        const fargateService = new ecs.FargateService(this, 'Service', {
+            cluster: fargateCluster,
+            taskDefinition: fargateTaskDef,
+            desiredCount: 1,
+            enableExecuteCommand: true
+        });
+
+        /**
+         * Create an ECS-on-EC2 Cluster that runs our traffic generation image
+         */
+
+        // 
+        const ecsAsg = new autoscaling.AutoScalingGroup(this, 'EcsASG', {
+            vpc: vpc,
+            instanceType: new ec2.InstanceType('t3.micro'), // Arbitrarily chosen
+            machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
+            desiredCapacity: 3,
+            minCapacity: 3,
+            maxCapacity: 10 // Arbitrarily chosen
+        });
+
+        const ecsCluster = new ecs.Cluster(this, 'EcsCluster', {
+            vpc: vpc,
+            executeCommandConfiguration: { kmsKey: ssmKey }
+        });
+
+        const ecsCapacityProvider = new ecs.AsgCapacityProvider(this, 'EcsCapacityProvider', {
+            autoScalingGroup: ecsAsg,
+        });
+        ecsCluster.addAsgCapacityProvider(ecsCapacityProvider);
+
+        const ecsTaskDef = new ecs.Ec2TaskDefinition(this, 'EcsTaskDef', {
+            networkMode: ecs.NetworkMode.BRIDGE,
+        });
+        ecsTaskDef.addToTaskRolePolicy(
+            new iam.PolicyStatement({
+                effect: iam.Effect.ALLOW,
+                actions: ['kms:Decrypt'], // Required for ECS Exec & shelling into the container
+                resources: [ssmKey.keyArn]
+            }),
+        );
+
+        const ecsContainer = ecsTaskDef.addContainer('EcsContainer', {
+            image: ecs.ContainerImage.fromAsset(path.resolve(__dirname, '..', '..', 'docker-traffic-gen')),
+            logging: new ecs.AwsLogDriver({ streamPrefix: 'DemoTrafficGenEcs', mode: ecs.AwsLogDriverMode.NON_BLOCKING }),
+
+            // Because we're using the BRIDGE network type for our ECS Tasks, we can only place a single container
+            // on each of our t3.micro instances.  We can't ask for all of their resources because ECS placement will
+            // fail, so we ask for a bit less than that.
+            cpu: 1536, // 1.5 vCPUs
+            memoryLimitMiB: 768, // 0.75 GiB
+        });
+
+        const ecsService = new ecs.Ec2Service(this, 'EcsService', {
+            cluster: ecsCluster,
+            taskDefinition: ecsTaskDef,
+            desiredCount: 1,
+            minHealthyPercent: 0,
+            enableExecuteCommand: true
+        });
     }
 }

--- a/manage_arkime/commands/add_vpc.py
+++ b/manage_arkime/commands/add_vpc.py
@@ -106,10 +106,10 @@ def _mirror_enis_in_subnet(event_bus_arn: str, cluster_name: str, vpc_id: str, s
         # actually create the mirroring configuration, we should pre-screen (hasn't already been mirrored; right eni
         # type).
 
-        logger.info(f"Initiating creation of mirroring session for ENI {eni.id}")
+        logger.info(f"Initiating creation of mirroring session for ENI {eni.eni_id}")
 
         events.put_events(
-            [events.CreateEniMirrorEvent(cluster_name, vpc_id, subnet_id, eni.id, eni.type, traffic_filter_id, vni)],
+            [events.CreateEniMirrorEvent(cluster_name, vpc_id, subnet_id, eni.eni_id, eni.eni_type, traffic_filter_id, vni)],
             event_bus_arn,
             aws_provider
         )

--- a/test_manage_arkime/test_add_vpc.py
+++ b/test_manage_arkime/test_add_vpc.py
@@ -14,8 +14,8 @@ import vni_provider as vnis
 @mock.patch("commands.add_vpc.ec2i")
 def test_WHEN_mirror_enis_in_subnet_called_THEN_sets_up_mirroring(mock_ec2i, mock_events):
     # Set up our mock
-    eni_1 = ec2i.NetworkInterface("eni-1", "type-1")
-    eni_2 = ec2i.NetworkInterface("eni-2", "type-2")
+    eni_1 = ec2i.NetworkInterface("vpc-1", "subnet-1", "eni-1", "type-1")
+    eni_2 = ec2i.NetworkInterface("vpc-1", "subnet-1", "eni-2", "type-2")
 
     mock_ec2i.get_enis_of_subnet.return_value = [eni_1, eni_2]
 

--- a/test_manage_arkime/test_create_eni_mirror_handler.py
+++ b/test_manage_arkime/test_create_eni_mirror_handler.py
@@ -46,7 +46,7 @@ def test_WHEN_CreateEniMirrorHandler_handle_called_THEN_sets_up_mirroring(mock_e
 
     expected_mirror_calls = [
         mock.call(
-            ec2i.NetworkInterface("eni-1", "eni-type-1"),
+            ec2i.NetworkInterface("vpc-1", "subnet-1", "eni-1", "eni-type-1"),
             "target-1",
             "filter-1",
             "vpc-1",
@@ -144,7 +144,7 @@ def test_WHEN_CreateEniMirrorHandler_handle_called_AND_wrong_type_THEN_aborts(mo
 
     mock_ec2i.NetworkInterface = ec2i.NetworkInterface
     mock_ec2i.NonMirrorableEniType = ec2i.NonMirrorableEniType
-    mock_ec2i.mirror_eni.side_effect = ec2i.NonMirrorableEniType(ec2i.NetworkInterface("eni-1", "eni-type-1"))
+    mock_ec2i.mirror_eni.side_effect = ec2i.NonMirrorableEniType(ec2i.NetworkInterface("vpc-1", "subnet-1", "eni-1", "eni-type-1"))
 
     mock_ssm_ops.ParamDoesNotExist = ParamDoesNotExist
     mock_ssm_ops.get_ssm_param_value.side_effect = ParamDoesNotExist("")
@@ -173,7 +173,7 @@ def test_WHEN_CreateEniMirrorHandler_handle_called_AND_wrong_type_THEN_aborts(mo
 
     expected_mirror_calls = [
         mock.call(
-            ec2i.NetworkInterface("eni-1", "eni-type-1"),
+            ec2i.NetworkInterface("vpc-1", "subnet-1", "eni-1", "eni-type-1"),
             "target-1",
             "filter-1",
             "vpc-1",


### PR DESCRIPTION
## Description
* Set up an EventBridge Rule to listen for EC2 instance stops and starts and direct them to the EventListener Lambda which converts them into Create/Destroy ENI Mirroring Events
* Added an ECS-on-EC2 cluster to the Demo Traffic Stacks which can be used to test the new rule.
* There's a potential race condition in the code.  We catch/process EC2 instance state change events, which only provide the instance ID.  We then use the instance ID to figure out which ENIs to stop mirroring by making an `ec2:DescribeInstances` API call.  The issues is that `terminated` EC2 instances don't have attached ENIs.  We catch/process the `shutting-down` event which precedes `terminated`, and the ENIs are still available then, but if there's an unexpected delay in processing it's possible that we might make our `ec2:DescribeInstances` call after the ENIs have been removed from the instance, at which point we won't know which ENI to tear mirroring down for.
* REMAINING WORK: Update the README to describe our Event Processing system

## Tasks
* https://github.com/arkime/cloud-demo/issues/37
* https://github.com/arkime/cloud-demo/issues/38

## Testing
* Added unit tests
* Manually added/removed capacity from the Demo Traffic Stack's new ASG to trigger EC2 Instance lifecycle events.  Lambda invocation logs below.

**AwsEventListener Lambda: EC2 Instance Running**
```
START RequestId: e03d2b90-f030-4de8-ab3e-23650e05c68d Version: $LATEST
Event:
{
    "version": "0",
    "id": "1f8939b9-6ce5-510c-13d7-a2821a5cc5c1",
    "detail-type": "EC2 Instance State-change Notification",
    "source": "aws.ec2",
    "account": "XXXXXXXXXXXX",
    "time": "2023-05-03T21:31:26Z",
    "region": "us-east-2",
    "resources": [
        "arn:aws:ec2:us-east-2:XXXXXXXXXXXX:instance/i-092528d09663600ee"
    ],
    "detail": {
        "instance-id": "i-092528d09663600ee",
        "state": "running"
    }
}

Pulling context from Lambda Environment Variables...
Event Bus ARN: arn:aws:events:us-east-2:XXXXXXXXXXXX:event-bus/MyClusterCaptureNodesClusterBus8101CEAA
Cluster Name: MyCluster
VPC ID: vpc-069bca118708c0fcb
Traffic Filter ID: tmf-0f88f3ec13c38bd6b
Mirror VNI: 42
Parsing AWS Service Event...
Event Type: EC2 Instance Running
Processing EC2 Instance: i-092528d09663600ee
Found credentials in environment variables.
ENIs:
[
{
    "vpc_id": "vpc-069bca118708c0fcb",
    "subnet_id": "subnet-0aeeeea40ba9b0406",
    "eni_id": "eni-010c2ec47525cf2aa",
    "eni_type": "interface"
}
]
Preparing CreateEniMirrorEvent: 
{
    "source": "arkime",
    "detail_type": "CreateEniMirror",
    "details": {
        "cluster_name": "MyCluster",
        "vpc_id": "vpc-069bca118708c0fcb",
        "subnet_id": "subnet-0aeeeea40ba9b0406",
        "eni_id": "eni-010c2ec47525cf2aa",
        "eni_type": "interface",
        "traffic_filter_id": "tmf-0f88f3ec13c38bd6b",
        "vni": 42
    }
}

Initiating creation of mirroring session(s) for 1 ENI(s)
Found credentials in environment variables.
END RequestId: e03d2b90-f030-4de8-ab3e-23650e05c68d
REPORT RequestId: e03d2b90-f030-4de8-ab3e-23650e05c68d  Duration: 4026.61 ms    Billed Duration: 4027 ms    Memory Size: 128 MB Max Memory Used: 85 MB  Init Duration: 291.43 ms
```

**CreateEniMirroring Lambda**
```
START RequestId: 2bfb9fc3-c613-448c-a1ab-b908f660a5b7 Version: $LATEST
Event:
{
    "version": "0",
    "id": "28c5223d-8808-71de-89fa-1a6f7e846d3d",
    "detail-type": "CreateEniMirror",
    "source": "arkime",
    "account": "XXXXXXXXXXXX",
    "time": "2023-05-03T21:31:31Z",
    "region": "us-east-2",
    "resources": [],
    "detail": {
        "cluster_name": "MyCluster",
        "vpc_id": "vpc-069bca118708c0fcb",
        "subnet_id": "subnet-0aeeeea40ba9b0406",
        "eni_id": "eni-010c2ec47525cf2aa",
        "eni_type": "interface",
        "traffic_filter_id": "tmf-0f88f3ec13c38bd6b",
        "vni": 42
    }
}
Starting Traffic Mirroring Session creation process for ENI eni-010c2ec47525cf2aa
Found credentials in environment variables.
Confirmed SSM Param does not exist for ENI eni-010c2ec47525cf2aa
Found credentials in environment variables.
Creating Mirroring Session...
Found credentials in environment variables.
Creating SSM Parameter: /arkime/clusters/MyCluster/vpcs/vpc-069bca118708c0fcb/subnets/subnet-0aeeeea40ba9b0406/enis/eni-010c2ec47525cf2aa
Found credentials in environment variables.
Found credentials in environment variables.
END RequestId: 2bfb9fc3-c613-448c-a1ab-b908f660a5b7
REPORT RequestId: 2bfb9fc3-c613-448c-a1ab-b908f660a5b7  Duration: 8040.07 ms    Billed Duration: 8041 ms    Memory Size: 128 MB Max Memory Used: 116 MB
```

**AwsEventListener Lambda: EC2 Instance Shutting Down**
```
START RequestId: 1687de52-72b4-4811-8930-f92a44d68f04 Version: $LATEST
Event:
{
    "version": "0",
    "id": "b48beeb8-eb10-1a28-e5ef-69867b242ff9",
    "detail-type": "EC2 Instance State-change Notification",
    "source": "aws.ec2",
    "account": "XXXXXXXXXXXX",
    "time": "2023-05-03T22:07:26Z",
    "region": "us-east-2",
    "resources": [
        "arn:aws:ec2:us-east-2:XXXXXXXXXXXX:instance/i-0bd5e40d8037dfb63"
    ],
    "detail": {
        "instance-id": "i-0bd5e40d8037dfb63",
        "state": "shutting-down"
    }
}

Pulling context from Lambda Environment Variables...
Event Bus ARN: arn:aws:events:us-east-2:XXXXXXXXXXXX:event-bus/MyClusterCaptureNodesClusterBus8101CEAA
Cluster Name: MyCluster
VPC ID: vpc-069bca118708c0fcb
Traffic Filter ID: tmf-0f88f3ec13c38bd6b
Mirror VNI: 43
Parsing AWS Service Event...
Event Type: EC2 Instance Shutting Down
Processing EC2 Instance: i-0bd5e40d8037dfb63
Found credentials in environment variables.
ENIs:
[
{
    "vpc_id": "vpc-069bca118708c0fcb",
    "subnet_id": "subnet-0aeeeea40ba9b0406",
    "eni_id": "eni-05198aa9f8d5a9787",
    "eni_type": "interface"
}
]
Preparing DestroyEniMirrorEvent: 
{
    "source": "arkime",
    "detail_type": "DestroyEniMirror",
    "details": {
        "cluster_name": "MyCluster",
        "vpc_id": "vpc-069bca118708c0fcb",
        "subnet_id": "subnet-0aeeeea40ba9b0406",
        "eni_id": "eni-05198aa9f8d5a9787"
    }
}

Initiating destruction of mirroring session(s) for 1 ENI(s)
Found credentials in environment variables.
END RequestId: 1687de52-72b4-4811-8930-f92a44d68f04
REPORT RequestId: 1687de52-72b4-4811-8930-f92a44d68f04  Duration: 3706.60 ms    Billed Duration: 3707 ms    Memory Size: 128 MB Max Memory Used: 85 MB  Init Duration: 233.52 ms
```

**DestroyEniMirroring Lambda**
```
START RequestId: 5c291c2a-fa8b-4c8d-b447-337ac6de1dbf Version: $LATEST
Event:
{
    "version": "0",
    "id": "a92dac89-8ed0-4d5f-6a11-fac6b351a533",
    "detail-type": "DestroyEniMirror",
    "source": "arkime",
    "account": "XXXXXXXXXXXX",
    "time": "2023-05-03T22:07:30Z",
    "region": "us-east-2",
    "resources": [],
    "detail": {
        "cluster_name": "MyCluster",
        "vpc_id": "vpc-069bca118708c0fcb",
        "subnet_id": "subnet-0aeeeea40ba9b0406",
        "eni_id": "eni-05198aa9f8d5a9787"
    }
}

Found credentials in environment variables.
Removing mirroring session for eni eni-05198aa9f8d5a9787: tms-03cefa0df79df536b...
Found credentials in environment variables.
Deleting SSM parameter for ENI eni-05198aa9f8d5a9787: /arkime/clusters/MyCluster/vpcs/vpc-069bca118708c0fcb/subnets/subnet-0aeeeea40ba9b0406/enis/eni-05198aa9f8d5a9787
Found credentials in environment variables.
Found credentials in environment variables.
END RequestId: 5c291c2a-fa8b-4c8d-b447-337ac6de1dbf
REPORT RequestId: 5c291c2a-fa8b-4c8d-b447-337ac6de1dbf  Duration: 6190.81 ms    Billed Duration: 6191 ms    Memory Size: 128 MB Max Memory Used: 100 MB Init Duration: 268.40 ms
```