### PR TITLE
enable mirroring of DNS traffic

### DIFF
--- a/cdk-lib/mirror-stacks/vpc-mirror-stack.ts
+++ b/cdk-lib/mirror-stacks/vpc-mirror-stack.ts
@@ -77,7 +77,8 @@ export class VpcMirrorStack extends Stack {
         // See: https://docs.aws.amazon.com/vpc/latest/mirroring/tm-example-non-vpc.html
         const filter = new ec2.CfnTrafficMirrorFilter(this, `Filter`, {
             description: 'Mirror non-local VPC traffic',
-            tags: [{key: 'Name', value: props.vpcId}]
+            tags: [{key: 'Name', value: props.vpcId}],
+            networkServices: ['amazon-dns']
         });
         new ec2.CfnTrafficMirrorFilterRule(this, `FRule-RejectLocalOutbound`, {
             destinationCidrBlock: '10.0.0.0/16', // TODO: Need to figure this out instead of hardcode


### PR DESCRIPTION
Traffic mirroring of DNS is off by default, this will enable it. We may want to add an option eventually to disable, but DNS monitoring is usually important for discovering beacons and such.

Tested by deploying.