### PR TITLE
Viewer Nodes use default self-signed cert for HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ You can log into your Viewer Dashboard using credentials from the `get-login-det
 ./manage_arkime.py get-login-details --name MyCluster
 ```
 
+**NOTE:** By default, we set up HTTPS using a self-signed certificate which your browser will give you a warning about when you visit the dashboard URL.  In \*most\* situations, you can just acknowledge the risk and click through.  However, if you're using Chrome on Mac OS you might not be allowed to click through ([see here](https://stackoverflow.com/questions/58802767/no-proceed-anyway-option-on-neterr-cert-invalid-in-chrome-on-macos)).  In that case, you'll need to click on the browser window so it's in focus and type the exact phrase `thisisunsafe` and it will let you through.
+
 ### Tearing down your Arkime Cluster
 
 You can destroy the Arkime Cluster in your AWS account by first turning off traffic capture for all VPCs:

--- a/cdk-lib/cloud-demo.ts
+++ b/cdk-lib/cloud-demo.ts
@@ -55,6 +55,7 @@ switch(params.type) {
 
         const viewerNodesStack = new ViewerNodesStack(app, params.nameViewerNodesStack, {
             env: env,
+            arnViewerCert: params.nameViewerCertArn,
             captureBucket: captureBucketStack.bucket,
             viewerVpc: captureVpcStack.vpc,
             clusterName: params.nameCluster,

--- a/cdk-lib/core/command-params.ts
+++ b/cdk-lib/core/command-params.ts
@@ -18,6 +18,7 @@ export interface ClusterMgmtParamsRaw extends CommandParamsRaw {
     nameClusterSsmParam: string;
     nameOSDomainStack: string;
     nameOSDomainSsmParam: string;
+    nameViewerCertArn: string;
     nameViewerDnsSsmParam: string;
     nameViewerPassSsmParam: string;
     nameViewerUserSsmParam: string;
@@ -79,6 +80,7 @@ export interface ClusterMgmtParams extends CommandParams {
     nameClusterSsmParam: string;
     nameOSDomainStack: string;
     nameOSDomainSsmParam: string;
+    nameViewerCertArn: string;
     nameViewerDnsSsmParam: string;
     nameViewerPassSsmParam: string;
     nameViewerUserSsmParam: string;

--- a/cdk-lib/core/context-wrangling.ts
+++ b/cdk-lib/core/context-wrangling.ts
@@ -93,6 +93,7 @@ function validateArgs(args: ValidateArgs) : (prms.ClusterMgmtParams | prms.Deplo
                 nameClusterSsmParam: rawClusterMgmtParamsObj.nameClusterSsmParam,
                 nameOSDomainStack: rawClusterMgmtParamsObj.nameOSDomainStack,
                 nameOSDomainSsmParam: rawClusterMgmtParamsObj.nameOSDomainSsmParam,
+                nameViewerCertArn: rawClusterMgmtParamsObj.nameViewerCertArn,
                 nameViewerDnsSsmParam: rawClusterMgmtParamsObj.nameViewerDnsSsmParam,
                 nameViewerPassSsmParam: rawClusterMgmtParamsObj.nameViewerPassSsmParam,
                 nameViewerUserSsmParam: rawClusterMgmtParamsObj.nameViewerUserSsmParam,

--- a/manage_arkime/aws_interactions/acm_interactions.py
+++ b/manage_arkime/aws_interactions/acm_interactions.py
@@ -42,3 +42,13 @@ def upload_default_elb_cert(aws_provider: AwsClientProvider) -> str:
 
     acm_arn = import_self_signed_cert(cert, aws_provider)
     return acm_arn
+
+def destroy_cert(cert_arn: str, aws_provider: AwsClientProvider):
+    logger.debug(f"Destroying ACM Certificate: {cert_arn}")
+
+    acm_client = aws_provider.get_acm()
+    acm_client.delete_certificate(
+        CertificateArn=cert_arn
+    )
+
+    logger.debug("ACM Certificate destroyed ")

--- a/manage_arkime/aws_interactions/acm_interactions.py
+++ b/manage_arkime/aws_interactions/acm_interactions.py
@@ -1,0 +1,44 @@
+from datetime import timedelta
+import logging
+
+from aws_interactions.aws_client_provider import AwsClientProvider
+from core.certificate_generation import SelfSignedCert
+
+logger = logging.getLogger(__name__)
+
+def import_self_signed_cert(cert: SelfSignedCert, aws_provider: AwsClientProvider) -> str:
+    """
+    Imports a self-signed cert into Amazon Certificate Manager and returns the ARN
+    """
+
+    logger.debug("Importing self-signed certificate into ACM...")
+
+    acm_client = aws_provider.get_acm()
+    import_response = acm_client.import_certificate(
+        Certificate=cert.get_cert_bytes(),
+        PrivateKey=cert.get_key_bytes(),
+    )
+
+    logger.debug("Self-signed certificate successfully imported")
+
+    return import_response["CertificateArn"]
+
+DEFAULT_ELB_DOMAIN = "*.elb.amazonaws.com"
+
+def upload_default_elb_cert(aws_provider: AwsClientProvider) -> str:
+    """
+    Generates a default, self-signed certificate for use on AWS ELB's, imports it into Amazon Certificate Manager, and
+    returns the ARN
+    """
+    logger.debug("Generating a default, self-signed certificate...")
+    cert = SelfSignedCert(
+        issuer_cn="Arkime",
+        subject_cn=DEFAULT_ELB_DOMAIN,
+        sans=[DEFAULT_ELB_DOMAIN],
+        validity_duration=timedelta(days=365*10) # You probably don't care about rotation if you're using self-signed
+    )
+    cert.generate()
+    logger.debug("Generated the certificate locally, now uploading...")
+
+    acm_arn = import_self_signed_cert(cert, aws_provider)
+    return acm_arn

--- a/manage_arkime/aws_interactions/acm_interactions.py
+++ b/manage_arkime/aws_interactions/acm_interactions.py
@@ -23,7 +23,7 @@ def import_self_signed_cert(cert: SelfSignedCert, aws_provider: AwsClientProvide
 
     return import_response["CertificateArn"]
 
-DEFAULT_ELB_DOMAIN = "*.elb.amazonaws.com"
+DEFAULT_ELB_DOMAIN = "localhost"
 
 def upload_default_elb_cert(aws_provider: AwsClientProvider) -> str:
     """

--- a/manage_arkime/aws_interactions/aws_client_provider.py
+++ b/manage_arkime/aws_interactions/aws_client_provider.py
@@ -17,6 +17,11 @@ class AwsClientProvider:
         else:
             return boto3.Session(profile_name=self._aws_profile, region_name=self._aws_region)
 
+    def get_acm(self):
+        session = self._get_session()
+        client = session.client("acm")
+        return client
+
     def get_cloudwatch(self):
         session = self._get_session()
         client = session.client("cloudwatch")

--- a/manage_arkime/cdk_interactions/cdk_context.py
+++ b/manage_arkime/cdk_interactions/cdk_context.py
@@ -4,17 +4,21 @@ from typing import Dict
 
 import constants as constants
 
-def generate_create_cluster_context(name: str) -> Dict[str, str]:
-    create_context = _generate_cluster_context(name)
+def generate_create_cluster_context(name: str, viewer_cert_arn: str) -> Dict[str, str]:
+    create_context = _generate_cluster_context(name, viewer_cert_arn)
     create_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_CREATE_CLUSTER
     return create_context
 
 def generate_destroy_cluster_context(name: str) -> Dict[str, str]:
-    destroy_context = _generate_cluster_context(name)
+    # Hardcode this value because it saves us some implementation headaches and it doesn't matter what it is. Since
+    # we're tearing down the Cfn stack in which it would be used, the operation either succeeds and the arn is
+    # irrelevant or it fails/rolls back and the arn is irrelevant.
+    fake_arn = "N/A"
+    destroy_context = _generate_cluster_context(name, fake_arn)
     destroy_context[constants.CDK_CONTEXT_CMD_VAR] = constants.CMD_DESTROY_CLUSTER
     return destroy_context
 
-def _generate_cluster_context(name: str) -> Dict[str, str]:
+def _generate_cluster_context(name: str, viewer_cert_arn: str) -> Dict[str, str]:
     cmd_params = {
         "nameCluster": name,
         "nameCaptureBucketStack": constants.get_capture_bucket_stack_name(name),
@@ -24,6 +28,7 @@ def _generate_cluster_context(name: str) -> Dict[str, str]:
         "nameClusterSsmParam": constants.get_cluster_ssm_param_name(name),
         "nameOSDomainStack": constants.get_opensearch_domain_stack_name(name),
         "nameOSDomainSsmParam": constants.get_opensearch_domain_ssm_param_name(name),
+        "nameViewerCertArn": viewer_cert_arn,
         "nameViewerDnsSsmParam": constants.get_viewer_dns_ssm_param_name(name),
         "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(name),
         "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(name),

--- a/manage_arkime/commands/create_cluster.py
+++ b/manage_arkime/commands/create_cluster.py
@@ -1,5 +1,8 @@
 import logging
 
+from aws_interactions.acm_interactions import upload_default_elb_cert
+from aws_interactions.aws_client_provider import AwsClientProvider
+import aws_interactions.ssm_operations as ssm_ops
 from cdk_interactions.cdk_client import CdkClient
 import constants as constants
 import cdk_interactions.cdk_context as context
@@ -9,6 +12,8 @@ logger = logging.getLogger(__name__)
 def cmd_create_cluster(profile: str, region: str, name: str):
     logger.debug(f"Invoking create-cluster with profile '{profile}' and region '{region}'")
 
+    cert_arn = _set_up_viewer_cert(profile, region, name)
+
     cdk_client = CdkClient()
     stacks_to_deploy = [
         constants.get_capture_bucket_stack_name(name),
@@ -17,5 +22,32 @@ def cmd_create_cluster(profile: str, region: str, name: str):
         constants.get_opensearch_domain_stack_name(name),
         constants.get_viewer_nodes_stack_name(name)
     ]
-    create_context = context.generate_create_cluster_context(name)
+    create_context = context.generate_create_cluster_context(name, cert_arn)
     cdk_client.deploy(stacks_to_deploy, aws_profile=profile, aws_region=region, context=create_context)
+
+def _set_up_viewer_cert(profile: str, region: str, name: str) -> str:
+    aws_provider = AwsClientProvider(aws_profile=profile, aws_region=region)
+
+    # Only set up the certificate if it doesn't exist
+    cert_ssm_param = constants.get_viewer_cert_ssm_param_name(name)
+    try:
+        cert_arn = ssm_ops.get_ssm_param_value(cert_ssm_param, aws_provider)
+        logger.debug(f"Viewer certificate already exists ({cert_arn}); skipping creation")
+        return cert_arn
+    except ssm_ops.ParamDoesNotExist:
+        pass
+
+    # Create our cert and set up our state
+    logger.debug("Viewer certificate does not exist; creating...")
+    cert_arn = upload_default_elb_cert(aws_provider)
+    logger.debug(f"Viewer certificate created: {cert_arn}")
+
+    logger.debug("Setting SSM Param for viewer certificate...")
+    ssm_ops.put_ssm_param(
+        cert_ssm_param,
+        cert_arn,
+        aws_provider,
+        f"A self-signed certificate for the Cluster {name} Viewer Nodes' ALB"
+    )
+
+    return cert_arn

--- a/manage_arkime/commands/get_login_details.py
+++ b/manage_arkime/commands/get_login_details.py
@@ -17,7 +17,7 @@ class LoginDetails:
     url: str
 
     def __str__(self):
-        return f"URL: https:\\\\{self.url}\nUsername: {self.username}\nPassword: {self.password}"
+        return f"URL: https://{self.url}\nUsername: {self.username}\nPassword: {self.password}"
 
 def cmd_get_login_details(profile: str, region: str, name: str) -> LoginDetails:
     logger.debug(f"Invoking get-login-details with profile '{profile}' and region '{region}'")

--- a/manage_arkime/commands/get_login_details.py
+++ b/manage_arkime/commands/get_login_details.py
@@ -17,7 +17,7 @@ class LoginDetails:
     url: str
 
     def __str__(self):
-        return f"URL: {self.url}\nUsername: {self.username}\nPassword: {self.password}"
+        return f"URL: https:\\\\{self.url}\nUsername: {self.username}\nPassword: {self.password}"
 
 def cmd_get_login_details(profile: str, region: str, name: str) -> LoginDetails:
     logger.debug(f"Invoking get-login-details with profile '{profile}' and region '{region}'")

--- a/manage_arkime/constants.py
+++ b/manage_arkime/constants.py
@@ -65,6 +65,9 @@ def get_opensearch_domain_ssm_param_name(cluster_name: str) -> str:
 def get_subnet_ssm_param_name(cluster_name: str, vpc_id: str, subnet_id: str) -> str:
     return f"{SSM_CLUSTERS_PREFIX}/{cluster_name}/vpcs/{vpc_id}/subnets/{subnet_id}"
 
+def get_viewer_cert_ssm_param_name(cluster_name: str) -> str:
+    return f"/arkime/clusters/{cluster_name}/viewer-cert"
+
 def get_viewer_dns_ssm_param_name(cluster_name: str) -> str:
     return f"/arkime/clusters/{cluster_name}/viewer-dns"
 

--- a/manage_arkime/core/__init__.py
+++ b/manage_arkime/core/__init__.py
@@ -1,0 +1,1 @@
+# Intentionally empty (for now)

--- a/manage_arkime/core/certificate_generation.py
+++ b/manage_arkime/core/certificate_generation.py
@@ -1,0 +1,100 @@
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+import datetime
+import logging
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+RSA_PUBLIC_EXPONENT = 65537 # Industry standard value for RSA key gen
+
+class CertNotYetGenerated(Exception):
+    def __init__(self):
+        super().__init__("The certificate for this object has not yet been generated")
+
+class KeyNotYetGenerated(Exception):
+    def __init__(self):
+        super().__init__("The private key for this object has not yet been generated")
+
+class SelfSignedCert:
+    def __init__(self, issuer_cn: str, subject_cn: str, sans: List[str], validity_duration: datetime.timedelta, key_size: int = 2048):
+        """
+        issuer_cn: Used for Issuer Common Name
+        subject_cn: Used for the Subject Common Name
+        sans: List of domains for the Subject Alternative Name field
+        validity_duration: Time period the cert will be valid for
+        key_size: RSA key size for the certificate
+        """
+        # Input fields
+        self._issuer_cn = issuer_cn
+        self._subject_cn = subject_cn
+        self._sans = sans
+        self._validity_duration = validity_duration
+        self._key_size = key_size
+
+        # Internal state
+        self._public_exponent: int = RSA_PUBLIC_EXPONENT
+        self._private_key = None
+        self._certificate = None
+
+    def generate(self):
+        logger.info("Generating self-signed certificate...")
+        if self._private_key or self._certificate:
+            logger.warning("Certificate already generated for this instance; aborting")
+            return
+
+        logger.debug("Generating RSA private key...")
+        self._private_key = rsa.generate_private_key(
+            public_exponent=self._public_exponent,
+            key_size=self._key_size,
+        )
+        logger.debug("RSA private key generated")
+
+        logger.debug("Preparing certificate for signing...")
+        issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, self._issuer_cn)])
+        subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, self._subject_cn)])
+
+        cert_builder = x509.CertificateBuilder()
+        cert_builder = cert_builder.subject_name(subject)
+        cert_builder = cert_builder.issuer_name(issuer)
+        cert_builder = cert_builder.public_key(self._private_key.public_key())
+        cert_builder = cert_builder.serial_number(x509.random_serial_number())
+        cert_builder = cert_builder.not_valid_before(datetime.datetime.utcnow())
+        cert_builder = cert_builder.not_valid_after(
+            datetime.datetime.utcnow() + self._validity_duration
+        )
+
+        san_objects = [x509.DNSName(domain) for domain in self._sans]
+        san = x509.SubjectAlternativeName(san_objects)
+        cert_builder = cert_builder.add_extension(san, critical=False)
+
+        logger.debug("Signing the certificate...")
+        self._certificate = cert_builder.sign(self._private_key, hashes.SHA256())
+        logger.info("Certificate generated")
+
+    def get_cert_bytes(self) -> bytes:
+        """
+        Returns the certificate as bytes in the PEM format
+        """
+        if not self._certificate:
+            logger.error("Certificate not yet generated")
+            raise CertNotYetGenerated()
+        
+        return self._certificate.public_bytes(serialization.Encoding.PEM)
+    
+    def get_key_bytes(self) -> bytes:
+        """
+        Returns the UNENCRYPTED private key as bytes in the PEM format
+        """
+        if not self._private_key:
+            logger.error("Private key not yet generated")
+            raise KeyNotYetGenerated()
+        
+        return self._private_key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        )

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,9 @@ setuptools.setup(
         "boto3",
         "click",
         "coloredlogs",
+        "cryptography",
         "pexpect",
         "pytest",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.9",
 )

--- a/test_manage_arkime/test_acm_interactions.py
+++ b/test_manage_arkime/test_acm_interactions.py
@@ -1,0 +1,64 @@
+from datetime import timedelta
+import unittest.mock as mock
+
+from aws_interactions.acm_interactions import import_self_signed_cert, upload_default_elb_cert, DEFAULT_ELB_DOMAIN
+
+
+def test_WHEN_import_self_signed_cert_called_THEN_imports():
+    # Set up our mock
+    mock_cert = mock.Mock()
+    mock_cert.get_cert_bytes.return_value = b'cert'
+    mock_cert.get_key_bytes.return_value = b'key'
+
+    mock_client = mock.Mock()
+    mock_client.import_certificate.return_value = {
+        "CertificateArn": "arn"
+    }
+    mock_provider = mock.Mock()
+    mock_provider.get_acm.return_value = mock_client
+
+    # Run our test
+    actual_value = import_self_signed_cert(mock_cert, mock_provider)
+
+    # Check our results
+    assert "arn" == actual_value
+
+    expected_import_calls = [
+        mock.call(Certificate=b'cert', PrivateKey=b'key')
+    ]
+    assert expected_import_calls == mock_client.import_certificate.call_args_list
+
+@mock.patch("aws_interactions.acm_interactions.import_self_signed_cert")
+@mock.patch("aws_interactions.acm_interactions.SelfSignedCert")
+def test_WHEN_upload_default_elb_cert_called_THEN_as_expected(mock_cert_cls, mock_import):
+    # Set up our mock
+    mock_cert = mock.Mock()
+    mock_cert_cls.return_value = mock_cert
+
+    mock_import.return_value = "arn"
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    actual_value = upload_default_elb_cert(mock_provider)
+
+    # Check our results
+    assert "arn" == actual_value
+
+    expected_cert_gen_calls = [
+        mock.call(
+            issuer_cn="Arkime",
+            subject_cn=DEFAULT_ELB_DOMAIN,
+            sans=[DEFAULT_ELB_DOMAIN],
+            validity_duration=timedelta(days=365*10)
+        )
+    ]
+    assert expected_cert_gen_calls == mock_cert_cls.call_args_list
+    
+    assert mock_cert.generate.called
+
+    expected_import_calls = [
+        mock.call(mock_cert, mock_provider)
+    ]
+    assert expected_import_calls == mock_import.call_args_list
+

--- a/test_manage_arkime/test_acm_interactions.py
+++ b/test_manage_arkime/test_acm_interactions.py
@@ -1,7 +1,7 @@
 from datetime import timedelta
 import unittest.mock as mock
 
-from aws_interactions.acm_interactions import import_self_signed_cert, upload_default_elb_cert, DEFAULT_ELB_DOMAIN
+from aws_interactions.acm_interactions import import_self_signed_cert, upload_default_elb_cert, DEFAULT_ELB_DOMAIN, destroy_cert
 
 
 def test_WHEN_import_self_signed_cert_called_THEN_imports():
@@ -61,4 +61,19 @@ def test_WHEN_upload_default_elb_cert_called_THEN_as_expected(mock_cert_cls, moc
         mock.call(mock_cert, mock_provider)
     ]
     assert expected_import_calls == mock_import.call_args_list
+
+def test_WHEN_destroy_cert_called_THEN_as_expected():
+    # Set up our mock
+    mock_client = mock.Mock()
+    mock_provider = mock.Mock()
+    mock_provider.get_acm.return_value = mock_client
+
+    # Run our test
+    destroy_cert("arn", mock_provider)
+
+    # Check our results
+    expected_destroy_cert_calls = [
+        mock.call(CertificateArn="arn")
+    ]
+    assert expected_destroy_cert_calls == mock_client.delete_certificate.call_args_list
 

--- a/test_manage_arkime/test_certificate_generation.py
+++ b/test_manage_arkime/test_certificate_generation.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timedelta
+import pytest
+import unittest.mock as mock
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import serialization
+
+from core.certificate_generation import SelfSignedCert, RSA_PUBLIC_EXPONENT, CertNotYetGenerated, KeyNotYetGenerated
+
+
+@mock.patch("core.certificate_generation.datetime")
+@mock.patch("core.certificate_generation.x509.CertificateBuilder")
+@mock.patch("core.certificate_generation.rsa")
+def test_WHEN_generate_called_THEN_generates_certificate(mock_rsa, mock_builder_cls, mock_datetime):
+    # Set up our mock
+    mock_key = mock.Mock()
+    mock_rsa.generate_private_key.return_value = mock_key
+
+    mock_cert = mock.Mock()
+    mock_builder = mock.Mock()
+    mock_builder.subject_name.return_value = mock_builder
+    mock_builder.issuer_name.return_value = mock_builder
+    mock_builder.public_key.return_value = mock_builder
+    mock_builder.serial_number.return_value = mock_builder
+    mock_builder.not_valid_before.return_value = mock_builder
+    mock_builder.not_valid_after.return_value = mock_builder
+    mock_builder.add_extension.return_value = mock_builder
+    mock_builder.sign.return_value = mock_cert
+    mock_builder_cls.return_value = mock_builder
+
+    now = datetime.utcnow()
+    mock_datetime.datetime.utcnow.return_value = now
+
+    # Run our test
+    test_cert = SelfSignedCert("issuer", "subject", ["san1", "san2"], timedelta(days=365), key_size=4096)
+    test_cert.generate()
+
+    # Check our results
+    expected_rsa_gen_calls = [
+        mock.call(public_exponent=RSA_PUBLIC_EXPONENT, key_size=4096)
+    ]
+    assert expected_rsa_gen_calls == mock_rsa.generate_private_key.call_args_list
+
+    assert mock_key == test_cert._private_key
+    assert mock_cert == test_cert._certificate
+
+    # Check the cert was created in the way we expected
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "subject")])
+    assert [mock.call(subject)] == mock_builder.subject_name.call_args_list
+
+    issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "issuer")])
+    assert [mock.call(issuer)] == mock_builder.issuer_name.call_args_list
+
+    assert [mock.call(mock_key.public_key())] == mock_builder.public_key.call_args_list
+
+    assert [mock.call(mock.ANY)] == mock_builder.serial_number.call_args_list
+
+    assert [mock.call(now)] == mock_builder.not_valid_before.call_args_list
+
+    assert [mock.call(now + timedelta(days=365))] == mock_builder.not_valid_after.call_args_list
+
+    san = x509.SubjectAlternativeName([
+        x509.DNSName("san1"),
+        x509.DNSName("san2"),
+    ])
+    assert [mock.call(san, critical=False)] == mock_builder.add_extension.call_args_list
+
+@mock.patch("core.certificate_generation.x509.CertificateBuilder")
+@mock.patch("core.certificate_generation.rsa")
+def test_WHEN_generate_called_AND_already_gen_THEN_aborts(mock_rsa, mock_builder_cls):
+    # Run our test
+    test_cert = SelfSignedCert("issuer", "subject", ["san1", "san2"], timedelta(days=365), key_size=4096)
+    test_cert._certificate = "blah"
+    test_cert._private_key = "blah"
+    test_cert.generate()
+
+    # Check our results
+    assert not mock_rsa.generate_private_key.called
+    assert not mock_builder_cls.called
+    
+def test_WHEN_get_cert_bytes_THEN_as_expected():
+    # TEST 1: Has been generated
+    test_cert_1 = SelfSignedCert("issuer", "subject", ["san1", "san2"], timedelta(days=365), key_size=4096)
+    mock_cert_1 = mock.Mock()
+    mock_cert_1.public_bytes.return_value = b"public"
+    test_cert_1._certificate = mock_cert_1
+
+    assert b"public" == test_cert_1.get_cert_bytes()
+    assert [mock.call(serialization.Encoding.PEM)] == mock_cert_1.public_bytes.call_args_list
+
+
+    # TEST 2: Has not been generated
+    test_cert_2 = SelfSignedCert("issuer", "subject", ["san1", "san2"], timedelta(days=365), key_size=4096)
+    test_cert_2._certificate = None
+
+    with pytest.raises(CertNotYetGenerated):
+        test_cert_2.get_cert_bytes()
+    
+@mock.patch("core.certificate_generation.serialization.NoEncryption")
+def test_WHEN_get_key_bytes_THEN_as_expected(mock_no_encryption_cls):
+    # TEST 1: Has been generated
+    mock_no_encryption = mock.Mock()
+    mock_no_encryption_cls.return_value = mock_no_encryption
+
+    test_cert_1 = SelfSignedCert("issuer", "subject", ["san1", "san2"], timedelta(days=365), key_size=4096)
+    mock_key_1 = mock.Mock()
+    mock_key_1.private_bytes.return_value = b"private"
+    test_cert_1._private_key = mock_key_1
+
+    assert b"private" == test_cert_1.get_key_bytes()
+    assert [mock.call(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=mock_no_encryption)
+        ] == mock_key_1.private_bytes.call_args_list
+    
+
+    # TEST 2: Has not been generated
+    test_cert_2 = SelfSignedCert("issuer", "subject", ["san1", "san2"], timedelta(days=365), key_size=4096)
+    test_cert_2._private_key = None
+
+    with pytest.raises(KeyNotYetGenerated):
+        test_cert_2.get_key_bytes()

--- a/test_manage_arkime/test_create_cluster.py
+++ b/test_manage_arkime/test_create_cluster.py
@@ -2,12 +2,17 @@ import json
 import shlex
 import unittest.mock as mock
 
-from commands.create_cluster import cmd_create_cluster
+import aws_interactions.ssm_operations as ssm_ops
+from commands.create_cluster import cmd_create_cluster, _set_up_viewer_cert
 import constants as constants
 
+
+@mock.patch("commands.create_cluster._set_up_viewer_cert")
 @mock.patch("commands.create_cluster.CdkClient")
-def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls):
+def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client_cls, mock_set_up):
     # Set up our mock
+    mock_set_up.return_value = "arn"
+
     mock_client = mock.Mock()
     mock_cdk_client_cls.return_value = mock_client
 
@@ -37,6 +42,7 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
                     "nameClusterSsmParam": constants.get_cluster_ssm_param_name("my-cluster"),
                     "nameOSDomainStack": constants.get_opensearch_domain_stack_name("my-cluster"),
                     "nameOSDomainSsmParam": constants.get_opensearch_domain_ssm_param_name("my-cluster"),
+                    "nameViewerCertArn": "arn",
                     "nameViewerDnsSsmParam": constants.get_viewer_dns_ssm_param_name("my-cluster"),
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name("my-cluster"),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name("my-cluster"),
@@ -46,3 +52,69 @@ def test_WHEN_cmd_create_cluster_called_THEN_cdk_command_correct(mock_cdk_client
         )
     ]
     assert expected_calls == mock_client.deploy.call_args_list
+
+    expected_set_up_calls = [
+        mock.call("profile", "region", "my-cluster")
+    ]
+    assert expected_set_up_calls == mock_set_up.call_args_list
+
+@mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
+@mock.patch("commands.create_cluster.upload_default_elb_cert")
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_set_up_viewer_cert_called_THEN_set_up_correctly(mock_ssm_ops, mock_upload):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+    mock_ssm_ops.get_ssm_param_value.side_effect = ssm_ops.ParamDoesNotExist("")
+
+    mock_upload.return_value = "arn"
+
+    # Run our test
+    actual_value = _set_up_viewer_cert("profile", "region", "my-cluster")
+
+    # Check our results
+    assert "arn" == actual_value
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_viewer_cert_ssm_param_name("my-cluster"), mock.ANY)
+    ]
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_value.call_args_list
+
+    expected_upload_calls = [
+        mock.call(mock.ANY)
+    ]
+    assert expected_upload_calls == mock_upload.call_args_list
+
+    expected_put_ssm_calls = [
+        mock.call(
+            constants.get_viewer_cert_ssm_param_name("my-cluster"),
+            "arn",
+            mock.ANY,
+            mock.ANY
+        )
+    ]
+    assert expected_put_ssm_calls == mock_ssm_ops.put_ssm_param.call_args_list
+
+@mock.patch("commands.create_cluster.AwsClientProvider", mock.Mock())
+@mock.patch("commands.create_cluster.upload_default_elb_cert")
+@mock.patch("commands.create_cluster.ssm_ops")
+def test_WHEN_set_up_viewer_cert_called_AND_already_exists_THEN_skips_creation(mock_ssm_ops, mock_upload):
+    # Set up our mock
+    mock_ssm_ops.ParamDoesNotExist = ssm_ops.ParamDoesNotExist
+    mock_ssm_ops.get_ssm_param_value.return_value = "arn"
+
+    # Run our test
+    actual_value = _set_up_viewer_cert("profile", "region", "my-cluster")
+
+    # Check our results
+    assert "arn" == actual_value
+
+    expected_get_ssm_calls = [
+        mock.call(constants.get_viewer_cert_ssm_param_name("my-cluster"), mock.ANY)
+    ]
+    assert expected_get_ssm_calls == mock_ssm_ops.get_ssm_param_value.call_args_list
+
+    expected_upload_calls = []
+    assert expected_upload_calls == mock_upload.call_args_list
+
+    expected_put_ssm_calls = []
+    assert expected_put_ssm_calls == mock_ssm_ops.put_ssm_param.call_args_list

--- a/test_manage_arkime/test_destroy_cluster.py
+++ b/test_manage_arkime/test_destroy_cluster.py
@@ -2,16 +2,18 @@ import json
 import shlex
 import unittest.mock as mock
 
-from commands.destroy_cluster import cmd_destroy_cluster
+from aws_interactions.ssm_operations import ParamDoesNotExist
+from commands.destroy_cluster import cmd_destroy_cluster, _destroy_viewer_cert
 import constants as constants
 
 TEST_CLUSTER = "my-cluster"
 
+@mock.patch("commands.destroy_cluster._destroy_viewer_cert")
 @mock.patch("commands.destroy_cluster.get_ssm_names_by_path")
 @mock.patch("commands.destroy_cluster.destroy_os_domain_and_wait")
 @mock.patch("commands.destroy_cluster.destroy_s3_bucket")
 @mock.patch("commands.destroy_cluster.CdkClient")
-def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expected_cmds(mock_cdk_client_cls, mock_destroy_bucket, mock_destroy_domain, mock_ssm_get):
+def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expected_cmds(mock_cdk_client_cls, mock_destroy_bucket, mock_destroy_domain, mock_ssm_get, mock_destroy_cert):
     # Set up our mock
     mock_ssm_get.return_value = []
 
@@ -44,6 +46,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
                     "nameClusterSsmParam": constants.get_cluster_ssm_param_name(TEST_CLUSTER),
                     "nameOSDomainStack": constants.get_opensearch_domain_stack_name(TEST_CLUSTER),
                     "nameOSDomainSsmParam": constants.get_opensearch_domain_ssm_param_name(TEST_CLUSTER),
+                    "nameViewerCertArn": "N/A",
                     "nameViewerDnsSsmParam": constants.get_viewer_dns_ssm_param_name(TEST_CLUSTER),
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(TEST_CLUSTER),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
@@ -54,13 +57,19 @@ def test_WHEN_cmd_destroy_cluster_called_AND_dont_destroy_everything_THEN_expect
     ]
     assert expected_calls == mock_client.destroy.call_args_list
 
+    expected_destroy_calls = [
+        mock.call(TEST_CLUSTER, mock.ANY)
+    ]
+    assert expected_destroy_calls == mock_destroy_cert.call_args_list    
+
 @mock.patch("commands.destroy_cluster.AwsClientProvider", mock.Mock())
+@mock.patch("commands.destroy_cluster._destroy_viewer_cert")
 @mock.patch("commands.destroy_cluster.get_ssm_names_by_path")
 @mock.patch("commands.destroy_cluster.destroy_os_domain_and_wait")
 @mock.patch("commands.destroy_cluster.destroy_s3_bucket")
 @mock.patch("commands.destroy_cluster.get_ssm_param_value")
 @mock.patch("commands.destroy_cluster.CdkClient")
-def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cmds(mock_cdk_client_cls, mock_get_ssm, mock_destroy_bucket, mock_destroy_domain, mock_ssm_names):
+def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cmds(mock_cdk_client_cls, mock_get_ssm, mock_destroy_bucket, mock_destroy_domain, mock_ssm_names, mock_destroy_cert):
     # Set up our mock
     mock_ssm_names.return_value = []
 
@@ -115,6 +124,7 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
                     "nameClusterSsmParam": constants.get_cluster_ssm_param_name(TEST_CLUSTER),
                     "nameOSDomainStack": constants.get_opensearch_domain_stack_name(TEST_CLUSTER),
                     "nameOSDomainSsmParam": constants.get_opensearch_domain_ssm_param_name(TEST_CLUSTER),
+                    "nameViewerCertArn": "N/A",
                     "nameViewerDnsSsmParam": constants.get_viewer_dns_ssm_param_name(TEST_CLUSTER),
                     "nameViewerPassSsmParam": constants.get_viewer_password_ssm_param_name(TEST_CLUSTER),
                     "nameViewerUserSsmParam": constants.get_viewer_user_ssm_param_name(TEST_CLUSTER),
@@ -124,6 +134,11 @@ def test_WHEN_cmd_destroy_cluster_called_AND_destroy_everything_THEN_expected_cm
         )
     ]
     assert expected_cdk_calls == mock_client.destroy.call_args_list
+
+    expected_destroy_calls = [
+        mock.call(TEST_CLUSTER, mock.ANY)
+    ]
+    assert expected_destroy_calls == mock_destroy_cert.call_args_list  
 
 @mock.patch("commands.destroy_cluster.get_ssm_names_by_path")
 @mock.patch("commands.destroy_cluster.destroy_os_domain_and_wait")
@@ -143,3 +158,64 @@ def test_WHEN_cmd_destroy_cluster_called_AND_existing_captures_THEN_abort(mock_c
     mock_destroy_bucket.assert_not_called()
     mock_destroy_domain.assert_not_called()
     mock_client.destroy.assert_not_called()
+
+@mock.patch("commands.destroy_cluster.delete_ssm_param")
+@mock.patch("commands.destroy_cluster.destroy_cert")
+@mock.patch("commands.destroy_cluster.get_ssm_param_value")
+def test_WHEN_destroy_viewer_cert_called_THEN_as_expected(mock_ssm_get, mock_destroy_cert, mock_ssm_delete):
+    # Set up our mock
+    mock_ssm_get.return_value = "arn"
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    _destroy_viewer_cert(TEST_CLUSTER, mock_provider)
+
+    # Check our results
+    expected_get_ssm_calls = [
+        mock.call(
+            constants.get_viewer_cert_ssm_param_name(TEST_CLUSTER),
+            mock_provider
+        )
+    ]
+    assert expected_get_ssm_calls == mock_ssm_get.call_args_list
+
+    expected_destroy_cert_calls = [
+        mock.call("arn", mock_provider)
+    ]
+    assert expected_destroy_cert_calls == mock_destroy_cert.call_args_list
+
+    expected_delete_ssm_calls = [
+        mock.call(
+            constants.get_viewer_cert_ssm_param_name(TEST_CLUSTER),
+            mock_provider
+        )
+    ]
+    assert expected_delete_ssm_calls == mock_ssm_delete.call_args_list
+
+@mock.patch("commands.destroy_cluster.delete_ssm_param")
+@mock.patch("commands.destroy_cluster.destroy_cert")
+@mock.patch("commands.destroy_cluster.get_ssm_param_value")
+def test_WHEN_destroy_viewer_cert_called_AND_doesnt_exist_THEN_skip(mock_ssm_get, mock_destroy_cert, mock_ssm_delete):
+    # Set up our mock
+    mock_ssm_get.side_effect = ParamDoesNotExist("")
+
+    mock_provider = mock.Mock()
+
+    # Run our test
+    _destroy_viewer_cert(TEST_CLUSTER, mock_provider)
+
+    # Check our results
+    expected_get_ssm_calls = [
+        mock.call(
+            constants.get_viewer_cert_ssm_param_name(TEST_CLUSTER),
+            mock_provider
+        )
+    ]
+    assert expected_get_ssm_calls == mock_ssm_get.call_args_list
+
+    expected_destroy_cert_calls = []
+    assert expected_destroy_cert_calls == mock_destroy_cert.call_args_list
+
+    expected_delete_ssm_calls = []
+    assert expected_delete_ssm_calls == mock_ssm_delete.call_args_list


### PR DESCRIPTION
## Description
* Added library code to generate self-signed x509 certs
* Added library code to generate/upload an generic, self-signed ELB cert
* Updated `create-cluster` and `destroy-cluster` to manage the cert and create an HTTPS Listener for the Viewer Nodes
* Updated `get-login-details` to print the HTTPS url

## Tasks
* https://github.com/arkime/cloud-demo/issues/50

## Testing
* Added unit tests
* Ran `get-login-details` to see the new URL
```
(.venv) chelma@3c22fba4e266 cloud-demo % ./manage_arkime.py get-login-details --name MyCluster2
2023-05-10 14:02:35 - Debug-level logs save to file: /Users/chelma/workspace/Arkime/cloud-demo/manage_arkime.log
2023-05-10 14:02:35 - Using AWS Credential Profile: default
2023-05-10 14:02:35 - Using AWS Region: default from AWS Config settings
2023-05-10 14:02:35 - Retrieving login details...
Log-in Details for Cluster 'MyCluster2'
==============================
URL: https:\\<my_domain>.us-east-2.elb.amazonaws.com
Username: admin
Password: <my_password>
```
* Updated my cluster and logged into it with the HTTPS URL.  Had to "acknowledge" the bad certificate warning that Firefox scares folks with.